### PR TITLE
Fixed bug with thumb immediate

### DIFF
--- a/Archs/ARM/CThumbInstruction.cpp
+++ b/Archs/ARM/CThumbInstruction.cpp
@@ -297,7 +297,7 @@ bool CThumbInstruction::Validate()
 
 		if (Vars.ImmediateBitLen != 32)
 		{
-			if ((unsigned int)Vars.Immediate >= (unsigned int)(1 << Vars.ImmediateBitLen))
+			if (abs(Vars.Immediate) >= (unsigned int)(1 << Vars.ImmediateBitLen))
 			{
 				Logger::queueError(Logger::Error,L"Immediate value %X out of range",Vars.Immediate);
 				return false;


### PR DESCRIPTION
Fixed bug where if a thumb immediate is a negative number it didn't report an out of range error.
