### PR TITLE
Don't write .pool label if pool is empty

### DIFF
--- a/Archs/ARM/Pool.cpp
+++ b/Archs/ARM/Pool.cpp
@@ -98,6 +98,9 @@ void ArmPoolCommand::writeTempData(TempData& tempData)
 
 void ArmPoolCommand::writeSymData(SymbolData& symData)
 {
-	symData.addLabel(RamPos,L".pool");
-	symData.addData(RamPos,Size*4,SymbolData::Data32);
+	if(Size > 0)
+	{
+		symData.addLabel(RamPos,L".pool");
+		symData.addData(RamPos,Size*4,SymbolData::Data32);
+	}
 }


### PR DESCRIPTION
Avoids the issue of .pool label prioritizing a potentially more important label at the same offset.
Previously code like 

```
label1:
nop
.pool
label2:
nop
```

would display a .pool label instead of label2 in nocash, which is not as useful.
