### PR TITLE
Fix compile errors on 64-bit linux

### DIFF
--- a/Archs/ARM/CArmInstruction.cpp
+++ b/Archs/ARM/CArmInstruction.cpp
@@ -175,7 +175,7 @@ bool CArmInstruction::ParseShift(char*& Line, int mode)
 typedef struct {
 	char Character;
 	bool type;
-	short StructOffset;
+	std::ptrdiff_t StructOffset;
 } tArmRegisterLookup;
 
 const tArmRegisterLookup RegisterLookup[] = {
@@ -228,7 +228,7 @@ bool CArmInstruction::LoadEncoding(const tArmOpcode& SourceOpcode, char* Line)
 				{
 					if (RegisterLookup[i].Character == *SourceEncoding)
 					{
-						Info = (tArmRegisterInfo*)((int) (&Vars) + RegisterLookup[i].StructOffset);
+						Info = (tArmRegisterInfo*)((uintptr_t) (&Vars) + RegisterLookup[i].StructOffset);
 						if (RegisterLookup[i].type == ARMREG_NORMAL)
 						{
 							if (ArmGetRegister(Line,RetLen,*Info) == false) return false;

--- a/Archs/ARM/CThumbInstruction.cpp
+++ b/Archs/ARM/CThumbInstruction.cpp
@@ -48,7 +48,7 @@ bool CThumbInstruction::Load(char *Name, char *Params)
 typedef struct {
 	char Character;
 	char MaxNum;
-	short StructOffset;
+	std::ptrdiff_t StructOffset;
 } tThumbRegisterLookup;
 
 #include <stddef.h>
@@ -92,7 +92,7 @@ bool CThumbInstruction::LoadEncoding(const tThumbOpcode& SourceOpcode, char* Lin
 				{
 					if (RegisterLookup[i].Character == *SourceEncoding)
 					{
-						Info = (tArmRegisterInfo*)((int) (&Vars) + RegisterLookup[i].StructOffset);
+						Info = (tArmRegisterInfo*)((uintptr_t) (&Vars) + RegisterLookup[i].StructOffset);
 						if (ArmGetRegister(Line,RetLen,*Info) == false) return false;
 						if (Info->Number > RegisterLookup[i].MaxNum) return false;
 						Line += RetLen;

--- a/Core/SymbolTable.h
+++ b/Core/SymbolTable.h
@@ -62,7 +62,7 @@ private:
 	struct SymbolInfo
 	{
 		SymbolType type;
-		unsigned int index;
+		size_t index;
 	};
 
 	struct Equation


### PR DESCRIPTION
While I was checking options for clang, I ran into a couple of compile errors caused by mixing 32-bit and 64-bit types. This patch replaces the problematic types with the types designed for pointer arithmetic.
