### PR TITLE
Make sure to close the file on error

### DIFF
--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -531,6 +531,12 @@ bool runArmips(ArmipsArguments& arguments)
 	bool result = !Logger::hasError();
 	if (result == true)
 		result = EncodeAssembly();
+	else if (g_fileManager->hasOpenFile())
+	{
+		if (!Global.memoryMode)
+			Logger::printError(Logger::Warning,L"File not closed");
+		g_fileManager->closeFile();
+	}
 
 	// return errors
 	if (arguments.errorsResult != NULL)


### PR DESCRIPTION
Maybe it shouldn't close in EncodeAssembly at all, though?

Not sure I understand the flow of closing the file.

-[Unknown]
