### PR TITLE
Avoid using Memory as a global symbol

### DIFF
--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -517,11 +517,11 @@ bool runArmips(ArmipsArguments& arguments)
 	// run assembler
 	switch (arguments.mode)
 	{
-	case ArmipsMode::File:
+	case ArmipsMode::FILE:
 		Global.memoryMode = false;
 		LoadAssemblyFile(arguments.inputFileName);
 		break;
-	case ArmipsMode::Memory:
+	case ArmipsMode::MEMORY:
 		Global.memoryMode = true;
 		Global.memoryFile = arguments.memoryFile;
 		LoadAssemblyContent(arguments.content);

--- a/Core/Assembler.h
+++ b/Core/Assembler.h
@@ -4,7 +4,7 @@
 #include "../Util/Util.h"
 #include "FileManager.h"
 
-enum class ArmipsMode { File, Memory };
+enum class ArmipsMode { FILE, MEMORY };
 
 struct LabelDefinition
 {
@@ -34,7 +34,7 @@ struct ArmipsArguments
 
 	ArmipsArguments()
 	{
-		mode = ArmipsMode::File;
+		mode = ArmipsMode::FILE;
 		errorOnWarning = false;
 		silent = false;
 		errorsResult = NULL;


### PR DESCRIPTION
This confuses Visual Studio's debugger, making it pick this Memory over the Memory namespace in PPSSPP.  Using caps prevents the overlap.

In other words, in Immediate, typing `Memory::base` or `Memory::Read_U32(addr)` would just give an error.  I know it's unfortunate to punish a dependency for this, but it's a small change.

-[Unknown]