### PR TITLE
Add basic N64 support.

### DIFF
--- a/Archs/MIPS/CMipsInstruction.cpp
+++ b/Archs/MIPS/CMipsInstruction.cpp
@@ -729,6 +729,11 @@ void CMipsInstruction::encodeNormal()
 		encoding |= registers.vrt.num >> 5;
 		encoding |= (registers.vrt.num & 0x1F) << 16;
 	}
+
+	if (Arch->getEndianness() == Endianness::Big)
+	{
+		encoding = swapEndianness32((u32)encoding);
+	}
 	
 	g_fileManager->write(&encoding,4);
 }
@@ -757,6 +762,11 @@ void CMipsInstruction::encodeVfpu()
 	case MipsImmediateType::Immediate7:
 		encoding |= immediate.value << 0;
 		break;
+	}
+
+	if (Arch->getEndianness() == Endianness::Big)
+	{
+		encoding = swapEndianness32((u32)encoding);
 	}
 
 	g_fileManager->write(&encoding,4);

--- a/Archs/MIPS/Mips.h
+++ b/Archs/MIPS/Mips.h
@@ -32,7 +32,7 @@ public:
 	virtual void Revalidate() { return; };
 	virtual int GetWordSize();
 	virtual IElfRelocator* getElfRelocator();
-	virtual Endianness getEndianness() { return Endianness::Little; };
+	virtual Endianness getEndianness() { return Version == MARCH_N64 ? Endianness::Big : Endianness::Little; };
 	void SetLoadDelay(bool Delay, int Register);
 	bool GetLoadDelay() { return LoadDelay; };
 	int GetLoadDelayRegister() { return LoadDelayRegister; };

--- a/Core/Directives.cpp
+++ b/Core/Directives.cpp
@@ -280,6 +280,14 @@ bool DirectivePsx(ArgumentList& List, int flags)
 	return true;
 }
 
+bool DirectiveN64(ArgumentList& List, int flags)
+{
+	Arch = &Mips;
+	Mips.SetLoadDelay(false,0);
+	Mips.SetVersion(MARCH_N64);
+	return true;
+}
+
 bool DirectivePs2(ArgumentList& List, int flags)
 {
 	Arch = &Mips;
@@ -757,6 +765,7 @@ const tDirective Directives[] = {
 	{ L".psp",				0,	0,	&DirectivePsp,				0 },
 	{ L".gba",				0,	0,	&DirectiveGba,				0 },
 	{ L".nds",				0,	0,	&DirectiveNds,				0 },
+	{ L".n64",				0,	0,	&DirectiveN64,				0 },
 	{ L".gb",				0,	0,	&DirectiveGb,				DIRECTIVE_DISABLED },
 	{ L".nocash",			0,	1,	&DirectiveNocash,			0 },
 	{ L".definelabel",		2,	2,	&DirectiveDefineLabel,		0 },


### PR DESCRIPTION
This lets me assemble a few instructions correctly. I’m not an N64 expert, though, and I don’t know what the N64 needs besides big‐endian instructions.