### PR TITLE
Remove "deprecated const wchar_t * to wchar_t *" warnings

### DIFF
--- a/Archs/MIPS/MipsMacros.cpp
+++ b/Archs/MIPS/MipsMacros.cpp
@@ -126,7 +126,7 @@ CAssemblerCommand* generateMipsMacroLoadStore(Parser& parser, MipsRegisterData& 
 		.endif
 	)";
 
-	wchar_t* op;
+	const wchar_t* op;
 	bool isCop = false;
 	switch (flags & (MIPSM_ACCESSMASK|MIPSM_LOAD|MIPSM_STORE))
 	{

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -7,9 +7,9 @@
 #include "Core/Common.h"
 #include "Util/Util.h"
 
-inline bool isPartOfList(const std::wstring& value, std::initializer_list<wchar_t*>& terminators)
+inline bool isPartOfList(const std::wstring& value, const std::initializer_list<const wchar_t*>& terminators)
 {
-	for (wchar_t* term: terminators)
+	for (const wchar_t* term: terminators)
 	{
 		if (value == term)
 			return true;
@@ -97,7 +97,7 @@ bool Parser::parseIdentifier(std::wstring& dest)
 	return true;
 }
 
-CAssemblerCommand* Parser::parseCommandSequence(wchar_t indicator, std::initializer_list<wchar_t*> terminators)
+CAssemblerCommand* Parser::parseCommandSequence(wchar_t indicator, const std::initializer_list<const wchar_t*> terminators)
 {
 	CommandSequence* sequence = new CommandSequence();
 

--- a/Parser/Parser.h
+++ b/Parser/Parser.h
@@ -37,10 +37,10 @@ public:
 	bool parseExpressionList(std::vector<Expression>& list, int min = -1, int max = -1);
 	bool parseIdentifier(std::wstring& dest);
 	CAssemblerCommand* parseCommand();
-	CAssemblerCommand* parseCommandSequence(wchar_t indicator = 0, std::initializer_list<wchar_t*> terminators = {});
+	CAssemblerCommand* parseCommandSequence(wchar_t indicator = 0, const std::initializer_list<const wchar_t*> terminators = {});
 	CAssemblerCommand* parseFile(TextFile& file, bool virtualFile = false);
 	CAssemblerCommand* parseString(const std::wstring& text);
-	CAssemblerCommand* parseTemplate(const std::wstring& text, std::initializer_list<AssemblyTemplateArgument> variables = {});
+	CAssemblerCommand* parseTemplate(const std::wstring& text, const std::initializer_list<AssemblyTemplateArgument> variables = {});
 	CAssemblerCommand* parseDirective(const DirectiveMap &directiveSet);
 	bool matchToken(TokenType type, bool optional = false);
 

--- a/Util/Util.cpp
+++ b/Util/Util.cpp
@@ -307,7 +307,7 @@ size_t replaceAll(std::wstring& str, const wchar_t* oldValue,const std::wstring&
 	return count;
 }
 
-bool startsWith(const std::wstring& str, wchar_t* value, size_t stringPos)
+bool startsWith(const std::wstring& str, const wchar_t* value, size_t stringPos)
 {
 	while (*value != 0 && stringPos < str.size())
 	{

--- a/Util/Util.h
+++ b/Util/Util.h
@@ -23,7 +23,7 @@ bool deleteFile(const std::wstring& fileName);;
 std::wstring toWLowercase(const std::string& str);
 std::wstring getFileNameFromPath(const std::wstring& path);
 size_t replaceAll(std::wstring& str, const wchar_t* oldValue,const std::wstring& newValue);
-bool startsWith(const std::wstring& str, wchar_t* value, size_t stringPos = 0);
+bool startsWith(const std::wstring& str, const wchar_t* value, size_t stringPos = 0);
 
 enum class OpenFileMode { ReadBinary, WriteBinary, ReadWriteBinary };
 FILE* openFile(const std::wstring& fileName, OpenFileMode mode);


### PR DESCRIPTION
This commit adds a few consts that removes the GCC complainments about passing string literals to functions that do not modify them.