### PR TITLE
Allow compilation when exceptions are disabled

### DIFF
--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -146,16 +146,20 @@ ExpressionValue expFuncRegExMatch(const std::wstring& funcName, const std::vecto
 	GET_PARAM(parameters,0,source);
 	GET_PARAM(parameters,1,regexString);
 
+#if ARMIPS_EXCEPTIONS
 	try
 	{
+#endif
 		std::wregex regex(*regexString);
 		bool found = std::regex_match(*source,regex);
 		return ExpressionValue(found ? UINT64_C(1) : UINT64_C(0));
+#if ARMIPS_EXCEPTIONS
 	} catch (std::regex_error&)
 	{
 		Logger::queueError(Logger::Error,L"Invalid regular expression");
 		return ExpressionValue();
 	}
+#endif
 }
 
 ExpressionValue expFuncRegExSearch(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
@@ -166,16 +170,20 @@ ExpressionValue expFuncRegExSearch(const std::wstring& funcName, const std::vect
 	GET_PARAM(parameters,0,source);
 	GET_PARAM(parameters,1,regexString);
 
+#if ARMIPS_EXCEPTIONS
 	try
 	{
+#endif
 		std::wregex regex(*regexString);
 		bool found = std::regex_search(*source,regex);
 		return ExpressionValue(found ? UINT64_C(1) : UINT64_C(0));
+#if ARMIPS_EXCEPTIONS
 	} catch (std::regex_error&)
 	{
 		Logger::queueError(Logger::Error,L"Invalid regular expression");
 		return ExpressionValue();
 	}
+#endif
 }
 
 ExpressionValue expFuncRegExExtract(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
@@ -188,8 +196,10 @@ ExpressionValue expFuncRegExExtract(const std::wstring& funcName, const std::vec
 	GET_PARAM(parameters,1,regexString);
 	GET_OPTIONAL_PARAM(parameters,2,matchIndex,0);
 
+#if ARMIPS_EXCEPTIONS
 	try
 	{
+#endif
 		std::wregex regex(*regexString);
 		std::wsmatch result;
 		bool found = std::regex_search(*source,result,regex);
@@ -200,11 +210,13 @@ ExpressionValue expFuncRegExExtract(const std::wstring& funcName, const std::vec
 		}
 	
 		return ExpressionValue(result[(size_t)matchIndex].str());
+#if ARMIPS_EXCEPTIONS
 	} catch (std::regex_error&)
 	{
 		Logger::queueError(Logger::Error,L"Invalid regular expression");
 		return ExpressionValue();
 	}
+#endif
 }
 
 ExpressionValue expFuncFind(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)

--- a/Core/FileManager.h
+++ b/Core/FileManager.h
@@ -8,6 +8,7 @@ enum class Endianness { Big, Little };
 class AssemblerFile
 {
 public:
+	virtual ~AssemblerFile() { };
 	
 	virtual bool open(bool onlyCheck) = 0;
 	virtual void close() = 0;

--- a/Util/Util.h
+++ b/Util/Util.h
@@ -32,4 +32,6 @@ std::wstring getCurrentDirectory();
 void changeDirectory(const std::wstring& dir);
 bool isAbsolutePath(const std::wstring& path);
 
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof((x)) / sizeof((x)[0]))
+#endif

--- a/stdafx.h
+++ b/stdafx.h
@@ -8,6 +8,20 @@
 typedef struct { double x, y; } __float128;
 #endif
 
+#if defined(__clang__)
+#if __has_feature(cxx_exceptions)
+#define ARMIPS_EXCEPTIONS 1
+#else
+#define ARMIPS_EXCEPTIONS 0
+#endif
+#elif defined(_MSC_VER) && defined(_CPPUNWIND)
+#define ARMIPS_EXCEPTIONS 1
+#elif defined(__EXCEPTIONS) || defined(__cpp_exceptions)
+#define ARMIPS_EXCEPTIONS 1
+#else
+#define ARMIPS_EXCEPTIONS 0
+#endif
+
 #include <cstdio>
 #include <vector>
 #include <cstdlib>


### PR DESCRIPTION
On Android, PPSSPP compiles without exceptions.  We also generally compile without armips.  However, our unit testing code uses armips to assemble unit tests, so it started failing to compile with the latest armips.

This simply ifdefs them off when they're disabled.

-[Unknown]