### PR TITLE
Add COP0 register name support to MIPS

### DIFF
--- a/Archs/MIPS/CMipsInstruction.h
+++ b/Archs/MIPS/CMipsInstruction.h
@@ -4,7 +4,7 @@
 #include "MipsOpcodes.h"
 #include "Core/Expression.h"
 
-enum class MipsRegisterType { Normal, Float, Ps2Cop2, VfpuVector, VfpuMatrix, RspCop2Vector, RspCop2VectorElement };
+enum class MipsRegisterType { Normal, Float, Cop0, Ps2Cop2, VfpuVector, VfpuMatrix, RspCop0, RspCop2Vector, RspCop2VectorElement };
 
 enum class MipsImmediateType { None, Immediate5, Immediate8, Immediate16, Immediate20, Immediate26,
 	Immediate20_0, ImmediateHalfFloat, Immediate7, Ext, Ins, Cop2BranchType };

--- a/Archs/MIPS/MipsOpcodes.cpp
+++ b/Archs/MIPS/MipsOpcodes.cpp
@@ -337,10 +337,12 @@ const tMipsOpcode MipsOpcodes[] = {
 //  10 |FUNCT* |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  | 10..17
 //  11 |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  | 18..1F
 //  hi |-------|-------|-------|-------|-------|-------|-------|-------|
-	{ "mfc0",	"t,d",		MIPS_COP0(0x00),				MA_MIPS1,	0 },
-	{ "dmfc0",	"t,d",		MIPS_COP0(0x01),				MA_MIPS3,	MO_64BIT },
-	{ "mtc0",	"t,d",		MIPS_COP0(0x04),				MA_MIPS1,	0 },
-	{ "dmtc0",	"t,d",		MIPS_COP0(0x05),				MA_MIPS3,	MO_64BIT },
+	{ "mfc0",	"t,z",		MIPS_COP0(0x00),				MA_MIPS1|MA_EXRSP,	0 },
+	{ "mfc0",	"t,Rz",		MIPS_COP0(0x00),				MA_RSP,		0 },
+	{ "dmfc0",	"t,z",		MIPS_COP0(0x01),				MA_MIPS3,	MO_64BIT },
+	{ "mtc0",	"t,z",		MIPS_COP0(0x04),				MA_MIPS1|MA_EXRSP,	0 },
+	{ "mtc0",	"t,Rz",		MIPS_COP0(0x04),				MA_RSP,		0 },
+	{ "dmtc0",	"t,z",		MIPS_COP0(0x05),				MA_MIPS3,	MO_64BIT },
 
 //     31--------------------21-------------------------------5--------0
 //     |=            COP0FUNCT|                              | function|
@@ -804,14 +806,14 @@ const tMipsOpcode MipsOpcodes[] = {
 	{ "vnor",	"Rd,Rs,Rt[Re]",		MIPS_COP2_RSP(0x2b),			MA_RSP, 0 },
 	{ "vxor",	"Rd,Rs,Rt[Re]",		MIPS_COP2_RSP(0x2c),			MA_RSP, 0 },
 	{ "vnxor",	"Rd,Rs,Rt[Re]",		MIPS_COP2_RSP(0x2d),			MA_RSP, 0 },
-	{ "vrcp",   "Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x30),			MA_RSP, 0 },
-	{ "vrcpl",  "Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x31),			MA_RSP, 0 },
-	{ "vrcph",  "Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x32),			MA_RSP, 0 },
-	{ "vmov",   "Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x33),			MA_RSP, 0 },
-	{ "vrsq",   "Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x34),			MA_RSP, 0 },
-	{ "vrsql",  "Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x35),			MA_RSP, 0 },
-	{ "vrsqh",  "Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x36),			MA_RSP, 0 },
-	{ "vnop",   "",					MIPS_COP2_RSP(0x37),			MA_RSP, 0 },
+	{ "vrcp",	"Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x30),			MA_RSP, 0 },
+	{ "vrcpl",	"Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x31),			MA_RSP, 0 },
+	{ "vrcph",	"Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x32),			MA_RSP, 0 },
+	{ "vmov",	"Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x33),			MA_RSP, 0 },
+	{ "vrsq",	"Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x34),			MA_RSP, 0 },
+	{ "vrsql",	"Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x35),			MA_RSP, 0 },
+	{ "vrsqh",	"Rd[Rx],Rt[Re]",	MIPS_COP2_RSP(0x36),			MA_RSP, 0 },
+	{ "vnop",	"",					MIPS_COP2_RSP(0x37),			MA_RSP, 0 },
 	{ "vextt",	"Rd,Rs,Rt[Re]",		MIPS_COP2_RSP(0x38),			MA_RSP, 0 },
 	{ "vextq",	"Rd,Rs,Rt[Re]",		MIPS_COP2_RSP(0x39),			MA_RSP, 0 },
 	{ "vextn",	"Rd,Rs,Rt[Re]",		MIPS_COP2_RSP(0x3a),			MA_RSP, 0 },

--- a/Archs/MIPS/MipsParser.h
+++ b/Archs/MIPS/MipsParser.h
@@ -17,10 +17,13 @@ public:
 	CMipsInstruction* parseOpcode(Parser& parser);
 	CAssemblerCommand* parseMacro(Parser& parser);
 private:
+	bool parseRegisterNumber(Parser& parser, MipsRegisterValue& dest);
 	bool parseRegisterTable(Parser& parser, MipsRegisterValue& dest, const MipsRegisterDescriptor* table, size_t count);
 	bool parseRegister(Parser& parser, MipsRegisterValue& dest);
 	bool parseFpuRegister(Parser& parser, MipsRegisterValue& dest);
+	bool parseCop0Register(Parser& parser, MipsRegisterValue& dest);
 	bool parsePs2Cop2Register(Parser& parser, MipsRegisterValue& dest);
+	bool parseRspCop0Register(Parser& parser, MipsRegisterValue& dest);
 	bool parseRspCop2Register(Parser& parser, MipsRegisterValue& dest);
 	bool parseRspCop2Element(Parser& parser, MipsRegisterValue& dest);
 	bool parseVfpuRegister(Parser& parser, MipsRegisterValue& reg, int size);


### PR DESCRIPTION
This PR adds a new register type for COP0 registers with support for official register names.

While, for example, ```mtc0 t0, $11``` is still supported, programs can now use ```mtc0 t0, Compare``` instead. The names added should be those defined in R4000, R4300 (N64) and R5900 (PS2), note however that some registers are not actually supported in all platforms, and this PR does not attempt to restrict the use of a specific register to platforms actually supporting it.

The same functionality, but with a different set of registers, was added to the RSP.