### PR TITLE
Add 0b prefix for binary literals

### DIFF
--- a/Parser/Tokenizer.cpp
+++ b/Parser/Tokenizer.cpp
@@ -421,6 +421,10 @@ bool FileTokenizer::convertInteger(size_t start, size_t end, u64& result)
 		{
 			base = 8;
 			start += 2;
+		} else if (tolower(currentLine[start+1]) == 'b')
+		{
+			base = 2;
+			start += 2;
 		}
 	}
 


### PR DESCRIPTION
This prefix is quite common in programming languages, some examples are C/C++ (technically non-standard until C++14), Python, Ruby, C# and Java. It would also fit well with the existing prefixes.