### PR TITLE
Add big endian support to ELF parser and relocator

### DIFF
--- a/Archs/MIPS/Mips.cpp
+++ b/Archs/MIPS/Mips.cpp
@@ -152,9 +152,9 @@ IElfRelocator* CMipsArchitecture::getElfRelocator()
 	{
 	case MARCH_PS2:
 	case MARCH_PSP:
+	case MARCH_N64:
 		return new MipsElfRelocator();
 	case MARCH_PSX:
-	case MARCH_N64:
 	case MARCH_RSP:
 	default:
 		return NULL;

--- a/Core/ELF/ElfFile.cpp
+++ b/Core/ELF/ElfFile.cpp
@@ -209,8 +209,8 @@ void ElfFile::determinePartOrder()
 		size_t pos = fileHeader.e_phoff+i*fileHeader.e_phentsize;
 		
 		Elf32_Phdr segmentHeader;
-		memcpy(&segmentHeader,&fileData[pos],sizeof(Elf32_Phdr));
-		size_t end = segmentHeader.p_offset+segmentHeader.p_filesz;
+		loadProgramHeader(segmentHeader, fileData, pos);
+		size_t end = segmentHeader.p_offset + segmentHeader.p_filesz;
 
 		if ((int)segmentHeader.p_offset < firstSegmentStart) firstSegmentStart = segmentHeader.p_offset;
 		if (lastSegmentEnd < end) lastSegmentEnd = end;
@@ -263,6 +263,53 @@ int ElfFile::findSegmentlessSection(const std::string& name)
 	return -1;
 }
 
+void ElfFile::loadElfHeader()
+{
+	memcpy(fileHeader.e_ident, &fileData[0], sizeof(fileHeader.e_ident));
+	bool bigEndian = (fileHeader.e_ident[5] == 0x02);
+	fileHeader.e_type = fileData.getWord(0x10, bigEndian);
+	fileHeader.e_machine = fileData.getWord(0x12, bigEndian);
+	fileHeader.e_version = fileData.getDoubleWord(0x14, bigEndian);
+	fileHeader.e_entry = fileData.getDoubleWord(0x18, bigEndian);
+	fileHeader.e_phoff = fileData.getDoubleWord(0x1C, bigEndian);
+	fileHeader.e_shoff = fileData.getDoubleWord(0x20, bigEndian);
+	fileHeader.e_flags = fileData.getDoubleWord(0x24, bigEndian);
+	fileHeader.e_ehsize = fileData.getWord(0x28, bigEndian);
+	fileHeader.e_phentsize = fileData.getWord(0x2A, bigEndian);
+	fileHeader.e_phnum = fileData.getWord(0x2C, bigEndian);
+	fileHeader.e_shentsize = fileData.getWord(0x2E, bigEndian);
+	fileHeader.e_shnum = fileData.getWord(0x30, bigEndian);
+	fileHeader.e_shstrndx = fileData.getWord(0x32, bigEndian);
+}
+
+void ElfFile::loadProgramHeader(Elf32_Phdr& header, ByteArray& data, int pos)
+{
+	bool bigEndian = (fileHeader.e_ident[5] == 0x02);
+	header.p_type   = data.getDoubleWord(pos + 0x00, bigEndian);
+	header.p_offset = data.getDoubleWord(pos + 0x04, bigEndian);
+	header.p_vaddr  = data.getDoubleWord(pos + 0x08, bigEndian);
+	header.p_paddr  = data.getDoubleWord(pos + 0x0C, bigEndian);
+	header.p_filesz = data.getDoubleWord(pos + 0x10, bigEndian);
+	header.p_memsz  = data.getDoubleWord(pos + 0x14, bigEndian);
+	header.p_flags  = data.getDoubleWord(pos + 0x18, bigEndian);
+	header.p_align  = data.getDoubleWord(pos + 0x1C, bigEndian);
+}
+
+void ElfFile::loadSectionHeader(Elf32_Shdr& header, ByteArray& data, int pos)
+{
+	bool bigEndian = (fileHeader.e_ident[5] == 0x02);
+	header.sh_name      = data.getDoubleWord(pos + 0x00, bigEndian);
+	header.sh_type      = data.getDoubleWord(pos + 0x04, bigEndian);
+	header.sh_flags     = data.getDoubleWord(pos + 0x08, bigEndian);
+	header.sh_addr      = data.getDoubleWord(pos + 0x0C, bigEndian);
+	header.sh_offset    = data.getDoubleWord(pos + 0x10, bigEndian);
+	header.sh_size      = data.getDoubleWord(pos + 0x14, bigEndian);
+	header.sh_link      = data.getDoubleWord(pos + 0x18, bigEndian);
+	header.sh_info      = data.getDoubleWord(pos + 0x1C, bigEndian);
+	header.sh_addralign = data.getDoubleWord(pos + 0x20, bigEndian);
+	header.sh_entsize   = data.getDoubleWord(pos + 0x24, bigEndian);
+}
+
 bool ElfFile::load(const std::wstring& fileName, bool sort)
 {
 	ByteArray data = ByteArray::fromFile(fileName);
@@ -275,7 +322,7 @@ bool ElfFile::load(ByteArray& data, bool sort)
 {
 	fileData = data;
 
-	memcpy(&fileHeader,&fileData[0],sizeof(Elf32_Ehdr));
+	loadElfHeader();
 	symTab = NULL;
 	strTab = NULL;
 
@@ -285,7 +332,7 @@ bool ElfFile::load(ByteArray& data, bool sort)
 		int pos = fileHeader.e_phoff+i*fileHeader.e_phentsize;
 		
 		Elf32_Phdr sectionHeader;
-		memcpy(&sectionHeader,&fileData[pos],sizeof(Elf32_Phdr));
+		loadProgramHeader(sectionHeader, fileData, pos);
 
 		ByteArray segmentData = fileData.mid(sectionHeader.p_offset,sectionHeader.p_filesz);
 		ElfSegment* segment = new ElfSegment(sectionHeader,segmentData);
@@ -298,7 +345,7 @@ bool ElfFile::load(ByteArray& data, bool sort)
 		int pos = fileHeader.e_shoff+i*fileHeader.e_shentsize;
 
 		Elf32_Shdr sectionHeader;
-		memcpy(&sectionHeader,&fileData[pos],sizeof(Elf32_Shdr));
+		loadSectionHeader(sectionHeader, fileData, pos);
 
 		ElfSection* section = new ElfSection(sectionHeader);
 		sections.push_back(section);
@@ -415,12 +462,22 @@ int ElfFile::getSymbolCount()
 	return symTab->getSize()/sizeof(Elf32_Sym);
 }
 
-Elf32_Sym* ElfFile::getSymbol(size_t index)
+bool ElfFile::getSymbol(Elf32_Sym& symbol, size_t index)
 {
 	if (symTab == NULL)
-		return NULL;
-	
-	return (Elf32_Sym*) &symTab->getData()[index*sizeof(Elf32_Sym)];
+		return false;
+
+	ByteArray &data = symTab->getData();
+	int pos = index*sizeof(Elf32_Sym);
+	bool bigEndian = (fileHeader.e_ident[5] == 0x02);
+	symbol.st_name  = data.getDoubleWord(pos + 0x00, bigEndian);
+	symbol.st_value = data.getDoubleWord(pos + 0x04, bigEndian);
+	symbol.st_size  = data.getDoubleWord(pos + 0x08, bigEndian);
+	symbol.st_info  = data[pos + 0x0C];
+	symbol.st_other = data[pos + 0x0D];
+	symbol.st_shndx = data.getWord(pos + 0x0E, bigEndian);
+
+	return true;
 }
 
 const char* ElfFile::getStrTableString(size_t pos)

--- a/Core/ELF/ElfFile.h
+++ b/Core/ELF/ElfFile.h
@@ -18,6 +18,7 @@ public:
 	void save(const std::wstring&fileName);
 
 	Elf32_Half getType() { return fileHeader.e_type; };
+	bool isBigEndian() { return (fileHeader.e_ident[0x5] == 0x02); }
 	size_t getSegmentCount() { return segments.size(); };
 	ElfSegment* getSegment(size_t index) { return segments[index]; };
 
@@ -27,9 +28,12 @@ public:
 	ByteArray& getFileData() { return fileData; }
 
 	int getSymbolCount();
-	Elf32_Sym* getSymbol(size_t index);
+	bool getSymbol(Elf32_Sym& symbol, size_t index);
 	const char* getStrTableString(size_t pos);
 private:
+	void loadElfHeader();
+	void loadProgramHeader(Elf32_Phdr& header, ByteArray& data, int pos);
+	void loadSectionHeader(Elf32_Shdr& header, ByteArray& data, int pos);
 	void loadSectionNames();
 	void determinePartOrder();
 

--- a/Core/ELF/ElfFile.h
+++ b/Core/ELF/ElfFile.h
@@ -18,7 +18,7 @@ public:
 	void save(const std::wstring&fileName);
 
 	Elf32_Half getType() { return fileHeader.e_type; };
-	bool isBigEndian() { return (fileHeader.e_ident[0x5] == 0x02); }
+	bool isBigEndian() { return (fileHeader.e_ident[EI_DATA] == ELFDATA2MSB); }
 	size_t getSegmentCount() { return segments.size(); };
 	ElfSegment* getSegment(size_t index) { return segments[index]; };
 
@@ -32,6 +32,7 @@ public:
 	const char* getStrTableString(size_t pos);
 private:
 	void loadElfHeader();
+	void writeHeader(ByteArray& data, int pos, bool bigEndian);
 	void loadProgramHeader(Elf32_Phdr& header, ByteArray& data, int pos);
 	void loadSectionHeader(Elf32_Shdr& header, ByteArray& data, int pos);
 	void loadSectionNames();
@@ -58,7 +59,7 @@ public:
 	void setData(ByteArray& data) { this->data = data; };
 	void setOwner(ElfSegment* segment);
 	bool hasOwner() { return owner != NULL; };
-	void writeHeader(byte* dest);
+	void writeHeader(ByteArray& data, int pos, bool bigEndian);
 	void writeData(ByteArray& output);
 	void setOffsetBase(int base);
 	ByteArray& getData() { return data; };
@@ -89,7 +90,7 @@ public:
 	Elf32_Word getType() { return header.p_type; };
 	Elf32_Addr getVirtualAddress() { return header.p_vaddr; };
 	size_t getSectionCount() { return sections.size(); };
-	void writeHeader(byte* dest);
+	void writeHeader(ByteArray& data, int pos, bool bigEndian);
 	void writeData(ByteArray& output);
 	void splitSections();
 

--- a/Core/ELF/ElfRelocator.h
+++ b/Core/ELF/ElfRelocator.h
@@ -61,6 +61,7 @@ public:
 	const ByteArray& getData() const { return outputData; };
 private:
 	bool relocateFile(ElfRelocatorFile& file, u64& relocationAddress);
+	void loadRelocation(Elf32_Rel& rel, ByteArray& data, int offset, bool bigEndian);
 
 	ByteArray outputData;
 	IElfRelocator* relocator;

--- a/Util/ByteArray.h
+++ b/Util/ByteArray.h
@@ -50,8 +50,23 @@ public:
 		} else {
 			return d[pos+3] | (d[pos+2] << 8) | (d[pos+1] << 16) | (d[pos+0] << 24);
 		}
-	};
+	}
 	
+	void replaceWord(size_t pos, unsigned int w, bool bigEndian = false)
+	{
+		if (pos+1 >= this->size()) return;
+		unsigned char* d = (unsigned char*) this->data();
+
+		if (bigEndian == false)
+		{
+			d[pos+0] = w & 0xFF;
+			d[pos+1] = (w >> 8) & 0xFF;
+		} else {
+			d[pos+0] = (w >> 8) & 0xFF;
+			d[pos+1] = w & 0xFF;
+		}
+	}
+
 	void replaceDoubleWord(size_t pos, unsigned int w, bool bigEndian = false)
 	{
 		if (pos+3 >= this->size()) return;


### PR DESCRIPTION
This PR makes the ELF file parser cognizant of endianness for both reading and writing.

Tested with MARCH_N64. All other archs untested, but I'm willing to do so if you can either provide object files or recommend some toolchains so I can produce my own.