### PR TITLE
Add various expression functions

### DIFF
--- a/Archs/MIPS/MipsElfFile.cpp
+++ b/Archs/MIPS/MipsElfFile.cpp
@@ -68,6 +68,13 @@ u64 MipsElfFile::getPhysicalAddress()
 	return -1;
 }
 
+size_t MipsElfFile::getHeaderSize()
+{
+	// this method is not used
+	Logger::queueError(Logger::Error,L"Unimplemented method");
+	return -1;
+}
+
 bool MipsElfFile::seekVirtual(u64 virtualAddress)
 {
 	// search in segments

--- a/Archs/MIPS/MipsElfFile.h
+++ b/Archs/MIPS/MipsElfFile.h
@@ -14,6 +14,7 @@ public:
 	virtual bool write(void* data, size_t length);
 	virtual u64 getVirtualAddress();
 	virtual u64 getPhysicalAddress();
+	virtual u64 getHeaderSize();
 	virtual bool seekVirtual(u64 virtualAddress);
 	virtual bool seekPhysical(u64 physicalAddress);
 	virtual bool getModuleInfo(SymDataModuleInfo& info);

--- a/Commands/CDirectiveFile.h
+++ b/Commands/CDirectiveFile.h
@@ -31,7 +31,7 @@ class CDirectivePosition: public CAssemblerCommand
 {
 public:
 	enum Type { Physical, Virtual };
-	CDirectivePosition(Type type, u64 position);
+	CDirectivePosition(Expression value, Type type);
 	virtual bool Validate();
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
@@ -39,6 +39,7 @@ public:
 private:
 	void exec() const;
 	Type type;
+	Expression expression;
 	u64 position;
 	u64 virtualAddress;
 };
@@ -91,13 +92,14 @@ private:
 class CDirectiveHeaderSize: public CAssemblerCommand
 {
 public:
-	CDirectiveHeaderSize(u64 size);
+	CDirectiveHeaderSize(Expression expression);
 	virtual bool Validate();
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const { };
 private:
-	void updateFile() const;
+	void exec() const;
+	Expression expression;
 	u64 headerSize;
 	u64 virtualAddress;
 };

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -101,6 +101,16 @@ ExpressionValue expFuncOrga(const std::wstring& funcName, const std::vector<Expr
 	return ExpressionValue((u64) g_fileManager->getPhysicalAddress());
 }
 
+ExpressionValue expFuncHeaderSize(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	if(!g_fileManager->hasOpenFile())
+	{
+		Logger::queueError(Logger::Error,L"headersize: no file opened");
+		return ExpressionValue();
+	}
+	return ExpressionValue((u64) g_fileManager->getHeaderSize());
+}
+
 ExpressionValue expFuncFileExists(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
 	const std::wstring* fileName;
@@ -466,6 +476,7 @@ const ExpressionFunctionMap expressionFunctions = {
 	{ L"outputname",	{ &expFuncOutputName,	0,	0,	false } },
 	{ L"org",			{ &expFuncOrg,			0,	0,	false } },
 	{ L"orga",			{ &expFuncOrga,			0,	0,	false } },
+	{ L"headersize",	{ &expFuncHeaderSize,	0,	0,	false } },
 	{ L"fileexists",	{ &expFuncFileExists,	1,	1,	true } },
 	{ L"filesize",		{ &expFuncFileSize,		1,	1,	true } },
 	{ L"tostring",		{ &expFuncToString,		1,	1,	true } },

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -81,6 +81,26 @@ ExpressionValue expFuncOutputName(const std::wstring& funcName, const std::vecto
 	return ExpressionValue(value);
 }
 
+ExpressionValue expFuncOrg(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	if(!g_fileManager->hasOpenFile())
+	{
+		Logger::queueError(Logger::Error,L"org: no file opened");
+		return ExpressionValue();
+	}
+	return ExpressionValue((u64) g_fileManager->getVirtualAddress());
+}
+
+ExpressionValue expFuncOrga(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	if(!g_fileManager->hasOpenFile())
+	{
+		Logger::queueError(Logger::Error,L"orga: no file opened");
+		return ExpressionValue();
+	}
+	return ExpressionValue((u64) g_fileManager->getPhysicalAddress());
+}
+
 ExpressionValue expFuncFileExists(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
 	const std::wstring* fileName;
@@ -444,6 +464,8 @@ const ExpressionFunctionMap expressionFunctions = {
 	{ L"version",		{ &expFuncVersion,		0,	0,	true } },
 	{ L"endianness",	{ &expFuncEndianness,	0,	0,	false } },
 	{ L"outputname",	{ &expFuncOutputName,	0,	0,	false } },
+	{ L"org",			{ &expFuncOrg,			0,	0,	false } },
+	{ L"orga",			{ &expFuncOrga,			0,	0,	false } },
 	{ L"fileexists",	{ &expFuncFileExists,	1,	1,	true } },
 	{ L"filesize",		{ &expFuncFileSize,		1,	1,	true } },
 	{ L"tostring",		{ &expFuncToString,		1,	1,	true } },

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -131,6 +131,84 @@ ExpressionValue expFuncToHex(const std::wstring& funcName, const std::vector<Exp
 	return ExpressionValue(formatString(L"%0*X",digits,value));
 }
 
+ExpressionValue expFuncInt(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	ExpressionValue result;
+
+	switch (parameters[0].type)
+	{
+	case ExpressionValueType::Integer:
+		result.intValue = parameters[0].intValue;
+		break;
+	case ExpressionValueType::Float:
+		result.intValue = (u64) parameters[0].floatValue;
+		break;
+	default:
+		return result;
+	}
+
+	result.type = ExpressionValueType::Integer;
+	return result;
+}
+
+ExpressionValue expFuncFloat(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	ExpressionValue result;
+
+	switch (parameters[0].type)
+	{
+	case ExpressionValueType::Integer:
+		result.floatValue = (double) parameters[0].intValue;
+		break;
+	case ExpressionValueType::Float:
+		result.floatValue = parameters[0].floatValue;
+		break;
+	default:
+		return result;
+	}
+
+	result.type = ExpressionValueType::Float;
+	return result;
+}
+
+ExpressionValue expFuncFrac(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	ExpressionValue result;
+	double intPart;
+
+	switch (parameters[0].type)
+	{
+	case ExpressionValueType::Float:
+		result.floatValue = modf(parameters[0].floatValue,&intPart);
+		break;
+	default:
+		return result;
+	}
+
+	result.type = ExpressionValueType::Float;
+	return result;
+}
+
+ExpressionValue expFuncAbs(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	ExpressionValue result;
+
+	switch (parameters[0].type)
+	{
+	case ExpressionValueType::Float:
+		result.type = ExpressionValueType::Float;
+		result.floatValue = fabs(parameters[0].floatValue);
+		break;
+	case ExpressionValueType::Integer:
+		result.type = ExpressionValueType::Integer;
+		result.intValue = (int64_t) parameters[0].intValue >= 0 ?
+			parameters[0].intValue : -parameters[0].intValue;
+		break;
+	}
+
+	return result;
+}
+
 ExpressionValue expFuncStrlen(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
 	const std::wstring* source;
@@ -370,6 +448,12 @@ const ExpressionFunctionMap expressionFunctions = {
 	{ L"filesize",		{ &expFuncFileSize,		1,	1,	true } },
 	{ L"tostring",		{ &expFuncToString,		1,	1,	true } },
 	{ L"tohex",			{ &expFuncToHex,		1,	2,	true } },
+
+	{ L"int",			{ &expFuncInt,			1,	1,	true } },
+	{ L"float",			{ &expFuncFloat,		1,	1,	true } },
+	{ L"frac",			{ &expFuncFrac,			1,	1,	true } },
+	{ L"abs",			{ &expFuncAbs,			1,	1,	true } },
+
 	{ L"strlen",		{ &expFuncStrlen,		1,	1,	true } },
 	{ L"substr",		{ &expFuncSubstr,		3,	3,	true } },
 	{ L"regex_match",	{ &expFuncRegExMatch,	2,	2,	true } },

--- a/Core/FileManager.cpp
+++ b/Core/FileManager.cpp
@@ -330,6 +330,13 @@ u64 FileManager::getPhysicalAddress()
 	return activeFile->getPhysicalAddress();
 }
 
+u64 FileManager::getHeaderSize()
+{
+	if (activeFile == NULL)
+		return -1;
+	return activeFile->getHeaderSize();
+}
+
 bool FileManager::seekVirtual(u64 virtualAddress)
 {
 	if (checkActiveFile() == false)

--- a/Core/FileManager.h
+++ b/Core/FileManager.h
@@ -16,6 +16,7 @@ public:
 	virtual bool write(void* data, size_t length) = 0;
 	virtual u64 getVirtualAddress() = 0;
 	virtual u64 getPhysicalAddress() = 0;
+	virtual size_t getHeaderSize() = 0;
 	virtual bool seekVirtual(u64 virtualAddress) = 0;
 	virtual bool seekPhysical(u64 physicalAddress) = 0;
 	virtual bool getModuleInfo(SymDataModuleInfo& info) { return false; };
@@ -37,6 +38,7 @@ public:
 	virtual bool write(void* data, size_t length);
 	virtual u64 getVirtualAddress() { return virtualAddress; };
 	virtual u64 getPhysicalAddress() { return virtualAddress-headerSize; };
+	virtual size_t getHeaderSize() { return headerSize; };
 	virtual bool seekVirtual(u64 virtualAddress);
 	virtual bool seekPhysical(u64 physicalAddress);
 	virtual bool hasFixedVirtualAddress() { return true; };
@@ -75,6 +77,7 @@ public:
 	bool writeU64(u64 data);
 	u64 getVirtualAddress();
 	u64 getPhysicalAddress();
+	size_t getHeaderSize();
 	bool seekVirtual(u64 virtualAddress);
 	bool seekPhysical(u64 physicalAddress);
 	bool advanceMemory(size_t bytes);

--- a/Parser/DirectivesParser.cpp
+++ b/Parser/DirectivesParser.cpp
@@ -98,28 +98,24 @@ CAssemblerCommand* parseDirectiveIncbin(Parser& parser, int flags)
 
 CAssemblerCommand* parseDirectivePosition(Parser& parser, int flags)
 {
-	const Token& start = parser.peekToken();
-
 	std::vector<Expression> list;
 	if (parser.parseExpressionList(list,1,1) == false)
 		return nullptr;
 
-	u64 position;
-	if (list[0].evaluateInteger(position) == false)
-	{
-		parser.printError(start,L"Invalid ram address");
-		return nullptr;
-	}
-
+	CDirectivePosition::Type type;
 	switch (flags & DIRECTIVE_USERMASK)
 	{
 	case DIRECTIVE_POS_PHYSICAL:
-		return new CDirectivePosition(CDirectivePosition::Physical,position);
+		type = CDirectivePosition::Physical;
+		break;
 	case DIRECTIVE_POS_VIRTUAL:
-		return new CDirectivePosition(CDirectivePosition::Virtual,position);
+		type = CDirectivePosition::Virtual;
+		break;
+	default:
+		return nullptr;
 	}
 
-	return nullptr;
+	return new CDirectivePosition(list[0],type);
 }
 
 CAssemblerCommand* parseDirectiveAlignFill(Parser& parser, int flags)
@@ -149,20 +145,11 @@ CAssemblerCommand* parseDirectiveAlignFill(Parser& parser, int flags)
 
 CAssemblerCommand* parseDirectiveHeaderSize(Parser& parser, int flags)
 {
-	const Token& start = parser.peekToken();
-
 	std::vector<Expression> list;
 	if (parser.parseExpressionList(list,1,1) == false)
 		return nullptr;
 
-	u64 size;
-	if (list[0].evaluateInteger(size) == false)
-	{
-		parser.printError(start,L"Invalid header size");
-		return nullptr;
-	}
-
-	return new CDirectiveHeaderSize(size);
+	return new CDirectiveHeaderSize(list[0]);
 }
 
 CAssemblerCommand* parseDirectiveObjImport(Parser& parser, int flags)


### PR DESCRIPTION
This PR adds these expression functions:

- `int(x)` for converting floats to integers
- `float(x)` for converting integers to floats
- `frac(x)` for getting the fractional part of a float
- `abs(x)` for getting the absolute value
- `orga()` for getting the current physical address
- `org()` for getting the current virtual address, same as `.` but added for symmetry
- `headersize()` for getting the current header size