### PR TITLE
Keep physical address when updating header size, support negative header sizes

### DIFF
--- a/Archs/MIPS/MipsElfFile.cpp
+++ b/Archs/MIPS/MipsElfFile.cpp
@@ -33,7 +33,7 @@ void MipsElfFile::endSymData()
 	Global.symData.endModule(this);
 }
 
-u64 MipsElfFile::getVirtualAddress()
+int64_t MipsElfFile::getVirtualAddress()
 {
 	if (segment != -1)
 	{
@@ -48,7 +48,7 @@ u64 MipsElfFile::getVirtualAddress()
 	return -1;
 }
 
-u64 MipsElfFile::getPhysicalAddress()
+int64_t MipsElfFile::getPhysicalAddress()
 {
 	if (segment != -1)
 	{
@@ -68,14 +68,14 @@ u64 MipsElfFile::getPhysicalAddress()
 	return -1;
 }
 
-size_t MipsElfFile::getHeaderSize()
+int64_t MipsElfFile::getHeaderSize()
 {
 	// this method is not used
 	Logger::queueError(Logger::Error,L"Unimplemented method");
 	return -1;
 }
 
-bool MipsElfFile::seekVirtual(u64 virtualAddress)
+bool MipsElfFile::seekVirtual(int64_t virtualAddress)
 {
 	// search in segments
 	for (size_t i = 0; i < elf.getSegmentCount(); i++)
@@ -112,7 +112,7 @@ bool MipsElfFile::seekVirtual(u64 virtualAddress)
 	return false;
 }
 
-bool MipsElfFile::seekPhysical(u64 physicalAddress)
+bool MipsElfFile::seekPhysical(int64_t physicalAddress)
 {
 	// search in segments
 	for (size_t i = 0; i < elf.getSegmentCount(); i++)

--- a/Archs/MIPS/MipsElfFile.h
+++ b/Archs/MIPS/MipsElfFile.h
@@ -12,11 +12,11 @@ public:
 	virtual void close();
 	virtual bool isOpen() { return opened; };
 	virtual bool write(void* data, size_t length);
-	virtual u64 getVirtualAddress();
-	virtual u64 getPhysicalAddress();
-	virtual u64 getHeaderSize();
-	virtual bool seekVirtual(u64 virtualAddress);
-	virtual bool seekPhysical(u64 physicalAddress);
+	virtual int64_t getVirtualAddress();
+	virtual int64_t getPhysicalAddress();
+	virtual int64_t getHeaderSize();
+	virtual bool seekVirtual(int64_t virtualAddress);
+	virtual bool seekPhysical(int64_t physicalAddress);
 	virtual bool getModuleInfo(SymDataModuleInfo& info);
 	virtual void beginSymData();
 	virtual void endSymData();

--- a/Commands/CDirectiveFile.h
+++ b/Commands/CDirectiveFile.h
@@ -11,9 +11,9 @@ public:
 	enum class Type { Invalid, Open, Create, Copy, Close };
 
 	CDirectiveFile();
-	void initOpen(const std::wstring& fileName, u64 memory);
-	void initCreate(const std::wstring& fileName, u64 memory);
-	void initCopy(const std::wstring& inputName, const std::wstring& outputName, u64 memory);
+	void initOpen(const std::wstring& fileName, int64_t memory);
+	void initCreate(const std::wstring& fileName, int64_t memory);
+	void initCopy(const std::wstring& inputName, const std::wstring& outputName, int64_t memory);
 	void initClose();
 
 	virtual bool Validate();
@@ -22,7 +22,7 @@ public:
 	virtual void writeSymData(SymbolData& symData) const;
 private:
 	Type type;
-	u64 virtualAddress;
+	int64_t virtualAddress;
 	GenericAssemblerFile* file;
 	AssemblerFile* closeFile;
 };
@@ -40,8 +40,8 @@ private:
 	void exec() const;
 	Type type;
 	Expression expression;
-	u64 position;
-	u64 virtualAddress;
+	int64_t position;
+	int64_t virtualAddress;
 };
 
 class CDirectiveIncbin: public CAssemblerCommand
@@ -57,13 +57,13 @@ public:
 	virtual void writeSymData(SymbolData& symData) const;
 private:
 	std::wstring fileName;
-	u64 fileSize;
+	int64_t fileSize;
 
 	Expression startExpression;
 	Expression sizeExpression;
-	u64 start;
-	u64 size;
-	u64 virtualAddress;
+	int64_t start;
+	int64_t size;
+	int64_t virtualAddress;
 };
 
 class CDirectiveAlignFill: public CAssemblerCommand
@@ -86,7 +86,7 @@ private:
 	u64 value;
 	u64 finalSize;
 	u8 fillByte;
-	u64 virtualAddress;
+	int64_t virtualAddress;
 };
 
 class CDirectiveHeaderSize: public CAssemblerCommand
@@ -100,8 +100,8 @@ public:
 private:
 	void exec() const;
 	Expression expression;
-	u64 headerSize;
-	u64 virtualAddress;
+	int64_t headerSize;
+	int64_t virtualAddress;
 };
 
 class DirectiveObjImport: public CAssemblerCommand

--- a/Core/FileManager.h
+++ b/Core/FileManager.h
@@ -14,11 +14,11 @@ public:
 	virtual void close() = 0;
 	virtual bool isOpen() = 0;
 	virtual bool write(void* data, size_t length) = 0;
-	virtual u64 getVirtualAddress() = 0;
-	virtual u64 getPhysicalAddress() = 0;
-	virtual size_t getHeaderSize() = 0;
-	virtual bool seekVirtual(u64 virtualAddress) = 0;
-	virtual bool seekPhysical(u64 physicalAddress) = 0;
+	virtual int64_t getVirtualAddress() = 0;
+	virtual int64_t getPhysicalAddress() = 0;
+	virtual int64_t getHeaderSize() = 0;
+	virtual bool seekVirtual(int64_t virtualAddress) = 0;
+	virtual bool seekPhysical(int64_t physicalAddress) = 0;
 	virtual bool getModuleInfo(SymDataModuleInfo& info) { return false; };
 	virtual bool hasFixedVirtualAddress() { return false; };
 	virtual void beginSymData() { };
@@ -29,31 +29,32 @@ public:
 class GenericAssemblerFile: public AssemblerFile
 {
 public:
-	GenericAssemblerFile(const std::wstring& fileName, u32 headerSize, bool overwrite);
-	GenericAssemblerFile(const std::wstring& fileName, const std::wstring& originalFileName, u32 headerSize);
+	GenericAssemblerFile(const std::wstring& fileName, int64_t headerSize, bool overwrite);
+	GenericAssemblerFile(const std::wstring& fileName, const std::wstring& originalFileName, int64_t headerSize);
 
 	virtual bool open(bool onlyCheck);
 	virtual void close() { if (handle.isOpen()) handle.close(); };
 	virtual bool isOpen() { return handle.isOpen(); };
 	virtual bool write(void* data, size_t length);
-	virtual u64 getVirtualAddress() { return virtualAddress; };
-	virtual u64 getPhysicalAddress() { return virtualAddress-headerSize; };
-	virtual size_t getHeaderSize() { return headerSize; };
-	virtual bool seekVirtual(u64 virtualAddress);
-	virtual bool seekPhysical(u64 physicalAddress);
+	virtual int64_t getVirtualAddress() { return virtualAddress; };
+	virtual int64_t getPhysicalAddress() { return virtualAddress-headerSize; };
+	virtual int64_t getHeaderSize() { return headerSize; };
+	virtual bool seekVirtual(int64_t virtualAddress);
+	virtual bool seekPhysical(int64_t physicalAddress);
 	virtual bool hasFixedVirtualAddress() { return true; };
 
 	virtual const std::wstring& getFileName() { return fileName; };
 	const std::wstring& getOriginalFileName() { return originalName; };
-	size_t getOriginalHeaderSize() { return originalHeaderSize; };
-	void setHeaderSize(size_t size) { headerSize = size; };
+	int64_t getOriginalHeaderSize() { return originalHeaderSize; };
+	void setHeaderSize(int64_t size) { headerSize = size; };
+
 private:
 	enum Mode { Open, Create, Copy };
 
 	Mode mode;
-	size_t originalHeaderSize;
-	size_t headerSize;
-	u64 virtualAddress;
+	int64_t originalHeaderSize;
+	int64_t headerSize;
+	int64_t virtualAddress;
 	BinaryFile handle;
 	std::wstring fileName;
 	std::wstring originalName;
@@ -75,11 +76,11 @@ public:
 	bool writeU16(u16 data);
 	bool writeU32(u32 data);
 	bool writeU64(u64 data);
-	u64 getVirtualAddress();
-	u64 getPhysicalAddress();
-	size_t getHeaderSize();
-	bool seekVirtual(u64 virtualAddress);
-	bool seekPhysical(u64 physicalAddress);
+	int64_t getVirtualAddress();
+	int64_t getPhysicalAddress();
+	int64_t getHeaderSize();
+	bool seekVirtual(int64_t virtualAddress);
+	bool seekPhysical(int64_t physicalAddress);
 	bool advanceMemory(size_t bytes);
 	AssemblerFile* getOpenFile() { return activeFile; };
 	void setEndianness(Endianness endianness) { this->endianness = endianness; };

--- a/Parser/DirectivesParser.cpp
+++ b/Parser/DirectivesParser.cpp
@@ -25,7 +25,7 @@ CAssemblerCommand* parseDirectiveOpen(Parser& parser, int flags)
 	if (parser.parseExpressionList(list,2,3) == false)
 		return nullptr;
 
-	u64 memoryAddress;
+	int64_t memoryAddress;
 	std::wstring inputName, outputName;
 
 	if (list[0].evaluateString(inputName,false) == false)
@@ -55,7 +55,7 @@ CAssemblerCommand* parseDirectiveCreate(Parser& parser, int flags)
 	if (parser.parseExpressionList(list,2,2) == false)
 		return nullptr;
 
-	u64 memoryAddress;
+	int64_t memoryAddress;
 	std::wstring inputName, outputName;
 
 	if (list[0].evaluateString(inputName,false) == false)


### PR DESCRIPTION
This PR changes the behaviour of `.headersize` in some ways.
It updates the address calculations so that the physical address is retained, previously `.headersize` without `.org` afterwards would result in weird address values. It also supports negative header sizes, which is useful if you have a block in the middle that needs to start with a PC lower than the physical address. The code checks that neither the physical nor the virtual address is negative.