### PR TITLE
Win32 build fixes and enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,16 @@
 cmake_minimum_required(VERSION 2.8)
 project(armips) 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11")
+if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11")
+endif()
+
+if(MSVC)
+	add_definitions(-DUNICODE -D_UNICODE)
+elseif(MINGW)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -municode")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+endif()
 
 include_directories(.)
 
@@ -108,3 +117,7 @@ add_executable(armips
 	
 	ext/tinyformat/tinyformat.h
 )
+
+if(WIN32)
+	target_link_libraries(armips shlwapi)
+endif(WIN32)

--- a/Core/Misc.cpp
+++ b/Core/Misc.cpp
@@ -4,8 +4,8 @@
 #include "Core/FileManager.h"
 #include <iostream>
 
-#ifdef _MSC_VER
-#include <Windows.h>
+#ifdef _WIN32
+#include <windows.h>
 #endif
 
 std::vector<Logger::QueueEntry> Logger::queue;

--- a/Main/Tests.h
+++ b/Main/Tests.h
@@ -2,7 +2,7 @@
 #include "Util/Util.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 class TestRunner

--- a/Main/main.cpp
+++ b/Main/main.cpp
@@ -29,8 +29,8 @@ int wmain(int argc, wchar_t* argv[])
 		return !runTests(argv[1]);
 #endif
 
-	Logger::printLine(L"%s Assembler v%d.%d.%d (" __DATE__ " " __TIME__ ") by Kingcom",
-		ARMIPSNAME,ARMIPS_VERSION_MAJOR,ARMIPS_VERSION_MINOR,ARMIPS_VERSION_REVISION);
+	Logger::printLine(L"%s Assembler v%d.%d.%d (%s %s) by Kingcom",
+		ARMIPSNAME,ARMIPS_VERSION_MAJOR,ARMIPS_VERSION_MINOR,ARMIPS_VERSION_REVISION,__DATE__,__TIME__);
 
 	StringList arguments = getStringListFromArray(argv,argc);
 

--- a/Util/FileClasses.cpp
+++ b/Util/FileClasses.cpp
@@ -1011,7 +1011,7 @@ void TextFile::writeCharacter(wchar_t character)
 	int length = 0;
 	if (character < 0x80)
 	{
-#ifdef WIN32
+#ifdef _WIN32
 		if (character == L'\n')
 		{
 			bufPut('\r');

--- a/Util/Util.cpp
+++ b/Util/Util.cpp
@@ -2,8 +2,8 @@
 #include "Util.h"
 #include <sys/stat.h>
 #ifdef _WIN32
-#include <Windows.h>
-#include <Shlwapi.h>
+#include <windows.h>
+#include <shlwapi.h>
 #else
 #include <unistd.h>
 #endif

--- a/armips.vcxproj
+++ b/armips.vcxproj
@@ -144,6 +144,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -157,6 +158,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tests|Win32'">
@@ -170,6 +172,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tests|x64'">
@@ -183,6 +186,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -199,6 +203,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -215,6 +220,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/stdafx.h
+++ b/stdafx.h
@@ -47,7 +47,3 @@ typedef uint64_t u64;
 
 #include "ext/tinyformat/tinyformat.h"
 #define formatString tfm::format
-
-#ifdef _WIN32
-#pragma comment(lib,"Shlwapi.lib")
-#endif


### PR DESCRIPTION
This PR allows armips to be built under MinGW from Linux and VS 2013. It also modifies the CMake build configuration to handle the Unicode flags needed during compiling and linking with shlwapi.lib. In theory, you can rely on cmake to generate the VS project files if you wanted to remove them from the repository, but I chose to keep them since they don't currently support the Tests configuration. I'm definitely open to comments and suggestions on this.

This should address the building issues raised in #43 and #52.