### PR TITLE
Fix Clang compilation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(armips) 
 
-if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11")
 endif()
 

--- a/stdafx.h
+++ b/stdafx.h
@@ -4,10 +4,6 @@
 #define _CRT_SECURE_NO_WARNINGS
 #undef __STRICT_ANSI__
 
-#ifdef __clang__
-typedef struct { double x, y; } __float128;
-#endif
-
 #if defined(__clang__)
 #if __has_feature(cxx_exceptions)
 #define ARMIPS_EXCEPTIONS 1


### PR DESCRIPTION
This PR fixes some Clang compilation issues. Unlike with GCC, however, warnings are not yet silenced. The changes have been tested in Linux and OS X 10.9.
The __float128 was removed as it doesn't seem to be used anywhere.