### PR TITLE
iOS buildfix

### DIFF
--- a/Util/Util.cpp
+++ b/Util/Util.cpp
@@ -171,8 +171,8 @@ u64 fileSize(const std::wstring& fileName)
 	return ((u64) attr.nFileSizeHigh << 32) | (u64) attr.nFileSizeLow;
 #else	
 	std::string utf8 = convertWStringToUtf8(fileName);
-	struct stat64 fileStat;
-	int err = stat64(utf8.c_str(),&fileStat);
+	struct stat fileStat;
+	int err = stat(utf8.c_str(),&fileStat);
 	if (0 != err)
 		return 0; 
 	return fileStat.st_size; 


### PR DESCRIPTION
stat64 is not available on all platforms.

Also this function is entirely unused anyway :)