### PR TITLE
Add a cmake option to enable/disable regexp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(armips) 
 
+option(ARMIPS_REGEXP "Enable regexp expression functions" ON)
+
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -Wno-uninitialized")
 endif()
 
 if(MSVC)
@@ -10,6 +12,10 @@ if(MSVC)
 elseif(MINGW)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -municode")
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+endif()
+
+if(ARMIPS_REGEXP)
+	add_definitions(-DARMIPS_REGEXP=1)
 endif()
 
 include_directories(.)

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -2,7 +2,9 @@
 #include "ExpressionFunctions.h"
 #include "Misc.h"
 #include "Common.h"
+#if ARMIPS_REGEXP
 #include <regex>
+#endif
 #include "../Archs/ARM/Arm.h"
 
 bool getExpFuncParameter(const std::vector<ExpressionValue>& parameters, size_t index, u64& dest,
@@ -281,6 +283,7 @@ ExpressionValue expFuncSubstr(const std::wstring& funcName, const std::vector<Ex
 	return ExpressionValue(source->substr((size_t)start,(size_t)count));
 }
 
+#if ARMIPS_REGEXP
 ExpressionValue expFuncRegExMatch(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
 	const std::wstring* source;
@@ -361,6 +364,7 @@ ExpressionValue expFuncRegExExtract(const std::wstring& funcName, const std::vec
 	}
 #endif
 }
+#endif
 
 ExpressionValue expFuncFind(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
@@ -512,9 +516,11 @@ const ExpressionFunctionMap expressionFunctions = {
 
 	{ L"strlen",		{ &expFuncStrlen,		1,	1,	true } },
 	{ L"substr",		{ &expFuncSubstr,		3,	3,	true } },
+#if ARMIPS_REGEXP
 	{ L"regex_match",	{ &expFuncRegExMatch,	2,	2,	true } },
 	{ L"regex_search",	{ &expFuncRegExSearch,	2,	2,	true } },
 	{ L"regex_extract",	{ &expFuncRegExExtract,	2,	3,	true } },
+#endif
 	{ L"find",			{ &expFuncFind,			2,	3,	true } },
 	{ L"rfind",			{ &expFuncRFind,		2,	3,	true } },
 


### PR DESCRIPTION
To work around https://github.com/android-ndk/ndk/issues/325 . Defaults to on, so is no change by itself.