### PR TITLE
Fix shift undefined behaviour in CArmInstruction

### DIFF
--- a/Archs/ARM/CArmInstruction.cpp
+++ b/Archs/ARM/CArmInstruction.cpp
@@ -32,12 +32,12 @@ int CArmInstruction::getShiftedImmediate(unsigned int num, int& ShiftAmount)
 {
 	for (int i = 0; i < 32; i+=2)
 	{
-		unsigned int andval = (0xFFFFFF00 >> i) | (0xFFFFFF00 << (32-i));
+		unsigned int andval = (0xFFFFFF00 >> i) | (0xFFFFFF00 << (-i & 31));
 
 		if ((num & andval) == 0)	// found it
 		{
 			ShiftAmount = i;
-			return (num << i) | (num >> (32 - i));
+			return (num << i) | (num >> (-i & 31));
 		}
 	}
 	return -1;


### PR DESCRIPTION
Fixes #108.

Shifting a N-bit value by N or more, which is done here when i=0, is actually undefined in C/C++. Accordingly Clang makes some kind of optimization in Release mode which causes this part to malfunction.

It would probably be a good idea to check the code base for undefined behaviour elsewhere.