### PR TITLE
Add hi/lo expression functions for MIPS

### DIFF
--- a/Archs/MIPS/MipsMacros.cpp
+++ b/Archs/MIPS/MipsMacros.cpp
@@ -104,20 +104,20 @@ CAssemblerCommand* generateMipsMacroLi(Parser& parser, MipsRegisterData& registe
 		.elseif %imm% & ~0xFFFF
 			.if (%imm% & 0xFFFF8000) == 0xFFFF8000
 				.if %lower%
-					addiu	%rs%,r0,%imm% & 0xFFFF
+					addiu	%rs%,r0, lo(%imm%)
 				.endif
 			.elseif (%imm% & 0xFFFF) == 0
 				.if %upper%
-					lui		%rs%,%imm% >> 16
+					lui		%rs%, hi(%imm%)
 				.elseif %lower%
 					nop
 				.endif
 			.else
 				.if %upper%
-					lui		%rs%,(%imm% >> 16) + ((%imm% & 0x8000) != 0)
+					lui		%rs%, hi(%imm%)
 				.endif
 				.if %lower%
-					addiu 	%rs%,%imm% & 0xFFFF
+					addiu 	%rs%, lo(%imm%)
 				.endif
 			.endif
 		.else
@@ -154,16 +154,16 @@ CAssemblerCommand* generateMipsMacroLoadStore(Parser& parser, MipsRegisterData& 
 			.error "Address too big"
 		.elseif %imm% < 0x8000 || (%imm% & 0xFFFF8000) == 0xFFFF8000
 			.if %lower%
-				%op%	%rs%,%imm% & 0xFFFF(r0)
+				%op%	%rs%, lo(%imm%)(r0)
 			.elseif %upper%
 				nop
 			.endif
 		.else
 			.if %upper%
-				lui		%temp%,(%imm% >> 16) + ((%imm% & 0x8000) != 0)
+				lui		%temp%, hi(%imm%)
 			.endif
 			.if %lower%
-				%op%	%rs%,%imm% & 0xFFFF(%temp%)
+				%op%	%rs%, lo(%imm%)(%temp%)
 			.endif
 		.endif
 	)";
@@ -657,7 +657,7 @@ const MipsMacroDefinition mipsMacros[] = {
 	{ L"sw.l",	L"s,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_W|MIPSM_LOWER },
 	{ L"sd.l",	L"s,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_DW|MIPSM_LOWER },
 	{ L"sc.l",	L"s,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_LLSCW|MIPSM_LOWER },
-	{ L"scd.l",	L"s,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_LLSCDW||MIPSM_LOWER },
+	{ L"scd.l",	L"s,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_LLSCDW|MIPSM_LOWER },
 	{ L"swc1.l",L"S,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_COP1|MIPSM_LOWER },
 	{ L"s.s.l",	L"S,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_COP1|MIPSM_LOWER },
 	{ L"swc2.l",L"S,I",		&generateMipsMacroLoadStore,		MIPSM_STORE|MIPSM_COP2|MIPSM_LOWER },

--- a/Archs/MIPS/MipsOpcodes.cpp
+++ b/Archs/MIPS/MipsOpcodes.cpp
@@ -95,6 +95,7 @@ const tMipsOpcode MipsOpcodes[] = {
 	{ "swr",	"t,i16(s)",			MIPS_OP(0x2E),			MA_MIPS1,	0 },
 	{ "swr",	"t,(s)",			MIPS_OP(0x2E),			MA_MIPS1,	0 },
 	{ "cache",	"jc,i16(s)",		MIPS_OP(0x2F),			MA_MIPS2,	0 },
+	{ "cache",	"jc,(s)",			MIPS_OP(0x2F),			MA_MIPS2,	0 },
 	{ "ll",		"t,i16(s)",			MIPS_OP(0x30),			MA_MIPS2,	MO_DELAYRT|MO_IGNORERTD },
 	{ "ll",		"t,(s)",			MIPS_OP(0x30),			MA_MIPS2,	MO_DELAYRT|MO_IGNORERTD },
 	{ "lwc1",	"T,i16(s)",			MIPS_OP(0x31),			MA_MIPS1,	0 },

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -499,6 +499,24 @@ ExpressionValue expFuncIsThumb(const std::wstring& funcName, const std::vector<E
 	return ExpressionValue(isThumb ? INT64_C(1) : INT64_C(0));
 }
 
+ExpressionValue expFuncHi(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	int64_t value;
+
+	GET_PARAM(parameters,0,value);
+
+	return ExpressionValue((int64_t)((value >> 16) + ((value & 0x8000) != 0)) & 0xFFFF);
+}
+
+ExpressionValue expFuncLo(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	int64_t value;
+
+	GET_PARAM(parameters,0,value);
+
+	return ExpressionValue(value & 0xFFFF);
+}
+
 const ExpressionFunctionMap expressionFunctions = {
 	{ L"version",		{ &expFuncVersion,			0,	0,	ExpFuncSafety::Safe } },
 	{ L"endianness",	{ &expFuncEndianness,		0,	0,	ExpFuncSafety::Unsafe } },
@@ -537,6 +555,9 @@ const ExpressionFunctionMap expressionFunctions = {
 	{ L"reads32",		{ &expFuncRead<int32_t>,	1,	2,	ExpFuncSafety::ConditionalUnsafe } },
 	{ L"reads64",		{ &expFuncRead<int64_t>,	1,	2,	ExpFuncSafety::ConditionalUnsafe } },
 	{ L"readascii",		{ &expFuncReadAscii,		1,	3,	ExpFuncSafety::ConditionalUnsafe } },
+
+	{ L"lo",			{ &expFuncLo,				1,	1,	ExpFuncSafety::Safe } },
+	{ L"hi",			{ &expFuncHi,				1,	1,	ExpFuncSafety::Safe } },
 
 	{ L"isarm",			{ &expFuncIsArm,			0,	0,	ExpFuncSafety::Safe } },
 	{ L"isthumb",		{ &expFuncIsThumb,			0,	0,	ExpFuncSafety::Safe } },


### PR DESCRIPTION
These expression functions work like `%hi` and `%lo` in other MIPS assemblers and are useful for simplifying pseudo-op macros and/or giving the user more manual control over generated ops while being able to use defined labels.
It would have been good if those functions were restricted to the MIPS mode, this is not done for now, however.