### PR TITLE
 Check machine and endianness field when linking ELF files

### DIFF
--- a/Archs/ARM/Arm.cpp
+++ b/Archs/ARM/Arm.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "Arm.h"
 #include "Core/Common.h"
-#include "ArmRelocator.h"
+#include "ArmElfRelocator.h"
 #include "ArmParser.h"
 #include "ArmExpressionFunctions.h"
 
@@ -66,9 +66,9 @@ void CArmArchitecture::NextSection()
 
 }
 
-IElfRelocator* CArmArchitecture::getElfRelocator()
+std::unique_ptr<IElfRelocator> CArmArchitecture::getElfRelocator()
 {
-	return new ArmElfRelocator(version != AARCH_GBA);
+	return std::unique_ptr<IElfRelocator>(new ArmElfRelocator(version != AARCH_GBA));
 }
 
 void CArmArchitecture::addPoolValue(ArmOpcodeCommand* command, int32_t value)

--- a/Archs/ARM/Arm.h
+++ b/Archs/ARM/Arm.h
@@ -41,7 +41,7 @@ public:
 	virtual void NextSection();
 	virtual void Pass2();
 	virtual void Revalidate();
-	virtual IElfRelocator* getElfRelocator();
+	virtual std::unique_ptr<IElfRelocator> getElfRelocator();
 	virtual Endianness getEndianness() { return version == AARCH_BIG ? Endianness::Big : Endianness::Little; };
 	void SetThumbMode(bool b) { thumb = b; };
 	bool GetThumbMode() { return thumb; };

--- a/Archs/ARM/ArmElfRelocator.cpp
+++ b/Archs/ARM/ArmElfRelocator.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include "ArmRelocator.h"
+#include "ArmElfRelocator.h"
 #include "Util/Util.h"
 #include "Arm.h"
 #include "Core/Common.h"
@@ -15,6 +15,11 @@ bool ArmElfRelocator::isDummyRelocationType(int type) const
 	// R_ARM_V4BX marks the position of a bx opcode, and does not
 	// cause any actual relocations
 	return type == R_ARM_V4BX;
+}
+
+int ArmElfRelocator::expectedMachine() const
+{
+	return EM_ARM;
 }
 
 /*

--- a/Archs/ARM/ArmElfRelocator.h
+++ b/Archs/ARM/ArmElfRelocator.h
@@ -16,9 +16,12 @@ class ArmElfRelocator: public IElfRelocator
 {
 public:
 	ArmElfRelocator(bool arm9): arm9(arm9) { };
+	virtual int expectedMachine() const;
 	virtual bool isDummyRelocationType(int type) const;
+
 	virtual bool relocateOpcode(int type, RelocationData& data);
 	virtual void setSymbolAddress(RelocationData& data, int64_t symbolAddress, int symbolType);
+
 	virtual CAssemblerCommand* generateCtorStub(std::vector<ElfRelocatorCtor>& ctors);
 private:
 	bool arm9;

--- a/Archs/Architecture.cpp
+++ b/Archs/Architecture.cpp
@@ -64,9 +64,9 @@ void CInvalidArchitecture::Revalidate()
 	Logger::printError(Logger::FatalError,L"No architecture specified");
 }
 
-IElfRelocator* CInvalidArchitecture::getElfRelocator()
+std::unique_ptr<IElfRelocator> CInvalidArchitecture::getElfRelocator()
 {
 	Logger::printError(Logger::FatalError,L"No architecture specified");
-	return NULL;
+	return nullptr;
 }
 

--- a/Archs/Architecture.h
+++ b/Archs/Architecture.h
@@ -2,8 +2,8 @@
 #include "../Commands/CAssemblerCommand.h"
 #include "../Core/ExpressionFunctions.h"
 #include "../Core/FileManager.h"
+#include "../Core/ELF/ElfRelocator.h"
 
-class IElfRelocator;
 class Tokenizer;
 class Parser;
 
@@ -16,7 +16,7 @@ public:
 	virtual void NextSection() = 0;
 	virtual void Pass2() = 0;
 	virtual void Revalidate() = 0;
-	virtual IElfRelocator* getElfRelocator() = 0;
+	virtual std::unique_ptr<IElfRelocator> getElfRelocator() = 0;
 	virtual Endianness getEndianness() = 0;
 private:
 	const ExpressionFunctionMap emptyMap = {};
@@ -43,8 +43,8 @@ public:
 	virtual void NextSection();
 	virtual void Pass2();
 	virtual void Revalidate();
-	virtual IElfRelocator* getElfRelocator();
-	virtual Endianness getEndianness() { return Endianness::Little; };
+	virtual std::unique_ptr<IElfRelocator> getElfRelocator();
+	virtual Endianness getEndianness() { return Endianness::Little; }
 };
 
 extern CInvalidArchitecture InvalidArchitecture;

--- a/Archs/MIPS/Mips.cpp
+++ b/Archs/MIPS/Mips.cpp
@@ -1,103 +1,10 @@
 #include "stdafx.h"
 #include "Mips.h"
 #include "MipsParser.h"
-#include "Parser/Parser.h"
 #include "MipsExpressionFunctions.h"
+#include "MipsElfRelocator.h"
 
 CMipsArchitecture Mips;
-
-bool MipsElfRelocator::relocateOpcode(int type, RelocationData& data)
-{
-	unsigned int p;
-
-	unsigned int op = data.opcode;
-	switch (type)
-	{
-	case R_MIPS_26: //j, jal
-		op = (op & 0xFC000000) | (((op&0x03FFFFFF)+(data.relocationBase>>2))&0x03FFFFFF);
-		break;
-	case R_MIPS_32:
-		op += (int) data.relocationBase;
-		break;
-	case R_MIPS_HI16:
-		p = (op & 0xFFFF) + (int) data.relocationBase;
-		op = (op&0xffff0000) | (((p >> 16) + ((p & 0x8000) != 0)) & 0xFFFF);
-		break;
-	case R_MIPS_LO16:
-		op = (op&0xffff0000) | (((op&0xffff)+data.relocationBase)&0xffff);
-		break;
-	default:
-		data.errorMessage = formatString(L"Unknown MIPS relocation type %d",type);
-		return false;
-	}
-
-	data.opcode = op;
-	return true;
-}
-
-void MipsElfRelocator::setSymbolAddress(RelocationData& data, int64_t symbolAddress, int symbolType)
-{
-	data.symbolAddress = symbolAddress;
-	data.targetSymbolType = symbolType;
-}
-
-const wchar_t* mipsCtorTemplate = LR"(
-	addiu	sp,-32
-	sw		ra,0(sp)
-	sw		s0,4(sp)
-	sw		s1,8(sp)
-	sw		s2,12(sp)
-	sw		s3,16(sp)
-	li		s0,%ctorTable%
-	li		s1,%ctorTable%+%ctorTableSize%
-	%outerLoopLabel%:
-	lw		s2,(s0)
-	lw		s3,4(s0)
-	addiu	s0,8
-	%innerLoopLabel%:
-	lw		a0,(s2)
-	jalr	a0
-	addiu	s2,4h
-	bne		s2,s3,%innerLoopLabel%
-	nop
-	bne		s0,s1,%outerLoopLabel%
-	nop
-	lw		ra,0(sp)
-	lw		s0,4(sp)
-	lw		s1,8(sp)
-	lw		s2,12(sp)
-	lw		s3,16(sp)
-	jr		ra
-	addiu	sp,32
-	%ctorTable%:
-	.word	%ctorContent%
-)";
-
-CAssemblerCommand* MipsElfRelocator::generateCtorStub(std::vector<ElfRelocatorCtor>& ctors)
-{
-	Parser parser;
-	if (ctors.size() != 0)
-	{
-		// create constructor table
-		std::wstring table;
-		for (size_t i = 0; i < ctors.size(); i++)
-		{
-			if (i != 0)
-				table += ',';
-			table += formatString(L"%s,%s+0x%08X",ctors[i].symbolName,ctors[i].symbolName,ctors[i].size);
-		}
-
-		return parser.parseTemplate(mipsCtorTemplate,{
-			{ L"%ctorTable%",		Global.symbolTable.getUniqueLabelName() },
-			{ L"%ctorTableSize%",	formatString(L"%d",ctors.size()*8) },
-			{ L"%outerLoopLabel%",	Global.symbolTable.getUniqueLabelName() },
-			{ L"%innerLoopLabel%",	Global.symbolTable.getUniqueLabelName() },
-			{ L"%ctorContent%",		table },
-		});
-	} else {
-		return parser.parseTemplate(L"jr ra :: nop");
-	}
-}
 
 CMipsArchitecture::CMipsArchitecture()
 {
@@ -145,14 +52,14 @@ void CMipsArchitecture::Revalidate()
 	DelaySlot = false;
 }
 
-IElfRelocator* CMipsArchitecture::getElfRelocator()
+std::unique_ptr<IElfRelocator> CMipsArchitecture::getElfRelocator()
 {
 	switch (Version)
 	{
 	case MARCH_PS2:
 	case MARCH_PSP:
 	case MARCH_N64:
-		return new MipsElfRelocator();
+		return std::unique_ptr<IElfRelocator>(new MipsElfRelocator());
 	case MARCH_PSX:
 	case MARCH_RSP:
 	default:

--- a/Archs/MIPS/Mips.h
+++ b/Archs/MIPS/Mips.h
@@ -4,22 +4,6 @@
 
 enum MipsArchType { MARCH_PSX = 0, MARCH_N64, MARCH_PS2, MARCH_PSP, MARCH_RSP, MARCH_INVALID };
 
-enum {
-	R_MIPS_NONE,
-	R_MIPS_16,
-	R_MIPS_32,
-	R_MIPS_REL32,
-	R_MIPS_26,
-	R_MIPS_HI16,
-	R_MIPS_LO16,
-	R_MIPS_GPREL16,
-	R_MIPS_LITERAL,
-	R_MIPS_GOT16,
-	R_MIPS_PC16,
-	R_MIPS_CALL16,
-	R_MIPS_GPREL32
-};
-
 class CMipsArchitecture: public CArchitecture
 {
 public:
@@ -30,7 +14,7 @@ public:
 	virtual void NextSection();
 	virtual void Pass2() { return; };
 	virtual void Revalidate();
-	virtual IElfRelocator* getElfRelocator();
+	virtual std::unique_ptr<IElfRelocator> getElfRelocator();
 	virtual Endianness getEndianness()
 	{
 		return Version == MARCH_N64 || Version == MARCH_RSP ? Endianness::Big : Endianness::Little;
@@ -86,10 +70,3 @@ bool MipsGetPs2VectorRegister(const char* source, int& RetLen, MipsRegisterInfo&
 int MipsGetFloatRegister(const char* source, int& RetLen);
 bool MipsCheckImmediate(const char* Source, Expression& Dest, int& RetLen);
 
-class MipsElfRelocator: public IElfRelocator
-{
-public:
-	virtual bool relocateOpcode(int type, RelocationData& data);
-	virtual void setSymbolAddress(RelocationData& data, int64_t symbolAddress, int symbolType);
-	virtual CAssemblerCommand* generateCtorStub(std::vector<ElfRelocatorCtor>& ctors);
-};

--- a/Archs/MIPS/MipsElfFile.cpp
+++ b/Archs/MIPS/MipsElfFile.cpp
@@ -270,7 +270,7 @@ DirectiveLoadMipsElf::DirectiveLoadMipsElf(const std::wstring& fileName)
 	if (file->load(this->inputName,this->inputName) == false)
 	{
 		delete file;
-		file = NULL;
+		file = nullptr;
 		return;
 	}
 	
@@ -286,7 +286,7 @@ DirectiveLoadMipsElf::DirectiveLoadMipsElf(const std::wstring& inputName, const 
 	if (file->load(this->inputName,this->outputName) == false)
 	{
 		delete file;
-		file = NULL;
+		file = nullptr;
 		return;
 	}
 	

--- a/Archs/MIPS/MipsElfRelocator.cpp
+++ b/Archs/MIPS/MipsElfRelocator.cpp
@@ -1,0 +1,101 @@
+#include "stdafx.h"
+#include "MipsElfRelocator.h"
+#include "Parser/Parser.h"
+
+int MipsElfRelocator::expectedMachine() const
+{
+	return EM_MIPS;
+}
+
+bool MipsElfRelocator::relocateOpcode(int type, RelocationData& data)
+{
+	unsigned int p;
+
+	unsigned int op = data.opcode;
+	switch (type)
+	{
+	case R_MIPS_26: //j, jal
+		op = (op & 0xFC000000) | (((op&0x03FFFFFF)+(data.relocationBase>>2))&0x03FFFFFF);
+		break;
+	case R_MIPS_32:
+		op += (int) data.relocationBase;
+		break;
+	case R_MIPS_HI16:
+		p = (op & 0xFFFF) + (int) data.relocationBase;
+		op = (op&0xffff0000) | (((p >> 16) + ((p & 0x8000) != 0)) & 0xFFFF);
+		break;
+	case R_MIPS_LO16:
+		op = (op&0xffff0000) | (((op&0xffff)+data.relocationBase)&0xffff);
+		break;
+	default:
+		data.errorMessage = formatString(L"Unknown MIPS relocation type %d",type);
+		return false;
+	}
+
+	data.opcode = op;
+	return true;
+}
+
+void MipsElfRelocator::setSymbolAddress(RelocationData& data, int64_t symbolAddress, int symbolType)
+{
+	data.symbolAddress = symbolAddress;
+	data.targetSymbolType = symbolType;
+}
+
+const wchar_t* mipsCtorTemplate = LR"(
+	addiu	sp,-32
+	sw		ra,0(sp)
+	sw		s0,4(sp)
+	sw		s1,8(sp)
+	sw		s2,12(sp)
+	sw		s3,16(sp)
+	li		s0,%ctorTable%
+	li		s1,%ctorTable%+%ctorTableSize%
+	%outerLoopLabel%:
+	lw		s2,(s0)
+	lw		s3,4(s0)
+	addiu	s0,8
+	%innerLoopLabel%:
+	lw		a0,(s2)
+	jalr	a0
+	addiu	s2,4h
+	bne		s2,s3,%innerLoopLabel%
+	nop
+	bne		s0,s1,%outerLoopLabel%
+	nop
+	lw		ra,0(sp)
+	lw		s0,4(sp)
+	lw		s1,8(sp)
+	lw		s2,12(sp)
+	lw		s3,16(sp)
+	jr		ra
+	addiu	sp,32
+	%ctorTable%:
+	.word	%ctorContent%
+)";
+
+CAssemblerCommand* MipsElfRelocator::generateCtorStub(std::vector<ElfRelocatorCtor>& ctors)
+{
+	Parser parser;
+	if (ctors.size() != 0)
+	{
+		// create constructor table
+		std::wstring table;
+		for (size_t i = 0; i < ctors.size(); i++)
+		{
+			if (i != 0)
+				table += ',';
+			table += formatString(L"%s,%s+0x%08X",ctors[i].symbolName,ctors[i].symbolName,ctors[i].size);
+		}
+
+		return parser.parseTemplate(mipsCtorTemplate,{
+			{ L"%ctorTable%",		Global.symbolTable.getUniqueLabelName() },
+			{ L"%ctorTableSize%",	formatString(L"%d",ctors.size()*8) },
+			{ L"%outerLoopLabel%",	Global.symbolTable.getUniqueLabelName() },
+			{ L"%innerLoopLabel%",	Global.symbolTable.getUniqueLabelName() },
+			{ L"%ctorContent%",		table },
+		});
+	} else {
+		return parser.parseTemplate(L"jr ra :: nop");
+	}
+}

--- a/Archs/MIPS/MipsElfRelocator.h
+++ b/Archs/MIPS/MipsElfRelocator.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "Core/ELF/ElfRelocator.h"
+
+enum {
+	R_MIPS_NONE,
+	R_MIPS_16,
+	R_MIPS_32,
+	R_MIPS_REL32,
+	R_MIPS_26,
+	R_MIPS_HI16,
+	R_MIPS_LO16,
+	R_MIPS_GPREL16,
+	R_MIPS_LITERAL,
+	R_MIPS_GOT16,
+	R_MIPS_PC16,
+	R_MIPS_CALL16,
+	R_MIPS_GPREL32
+};
+
+class MipsElfRelocator: public IElfRelocator
+{
+public:
+	virtual int expectedMachine() const;
+	virtual bool relocateOpcode(int type, RelocationData& data);
+	virtual void setSymbolAddress(RelocationData& data, int64_t symbolAddress, int symbolType);
+	virtual CAssemblerCommand* generateCtorStub(std::vector<ElfRelocatorCtor>& ctors);
+};

--- a/Archs/MIPS/PsxRelocator.h
+++ b/Archs/MIPS/PsxRelocator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Util/ByteArray.h"
 #include "Core/SymbolTable.h"
-#include "Mips.h"
+#include "MipsElfRelocator.h"
 #include "Commands/CAssemblerCommand.h"
 
 enum class PsxRelocationType { WordLiteral, UpperImmediate, LowerImmediate, FunctionCall };

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,12 @@ add_library(armips STATIC
 	Archs/ARM/Arm.h
 	Archs/ARM/ArmExpressionFunctions.cpp
 	Archs/ARM/ArmExpressionFunctions.h
+	Archs/ARM/ArmElfRelocator.cpp
+	Archs/ARM/ArmElfRelocator.h
 	Archs/ARM/ArmOpcodes.cpp
 	Archs/ARM/ArmOpcodes.h
 	Archs/ARM/ArmParser.cpp
 	Archs/ARM/ArmParser.h
-	Archs/ARM/ArmRelocator.cpp
-	Archs/ARM/ArmRelocator.h
 	Archs/ARM/CArmInstruction.cpp
 	Archs/ARM/CArmInstruction.h
 	Archs/ARM/CThumbInstruction.cpp
@@ -51,6 +51,8 @@ add_library(armips STATIC
 	Archs/MIPS/MipsElfFile.h
 	Archs/MIPS/MipsExpressionFunctions.cpp
 	Archs/MIPS/MipsExpressionFunctions.h
+	Archs/MIPS/MipsElfRelocator.cpp
+	Archs/MIPS/MipsElfRelocator.h
 	Archs/MIPS/MipsMacros.cpp
 	Archs/MIPS/MipsMacros.h
 	Archs/MIPS/MipsOpcodes.cpp

--- a/Commands/CDirectiveFile.h
+++ b/Commands/CDirectiveFile.h
@@ -38,8 +38,8 @@ public:
 	virtual void writeSymData(SymbolData& symData) const { };
 private:
 	void exec() const;
-	Type type;
 	Expression expression;
+	Type type;
 	int64_t position;
 	int64_t virtualAddress;
 };
@@ -61,8 +61,8 @@ private:
 
 	Expression startExpression;
 	Expression sizeExpression;
-	int64_t start;
 	int64_t size;
+	int64_t start;
 	int64_t virtualAddress;
 };
 

--- a/Core/ELF/ElfFile.cpp
+++ b/Core/ELF/ElfFile.cpp
@@ -22,7 +22,7 @@ bool compareSection(ElfSection* a, ElfSection* b)
 
 ElfSection::ElfSection(Elf32_Shdr header): header(header)
 {
-	owner = NULL;
+	owner = nullptr;
 }
 
 void ElfSection::setOwner(ElfSegment* segment)
@@ -31,18 +31,18 @@ void ElfSection::setOwner(ElfSegment* segment)
 	owner = segment;
 }
 
-void ElfSection::writeHeader(ByteArray& data, int pos, bool bigEndian)
+void ElfSection::writeHeader(ByteArray& data, int pos, Endianness endianness)
 {
-	data.replaceDoubleWord(pos + 0x00, header.sh_name, bigEndian);
-	data.replaceDoubleWord(pos + 0x04, header.sh_type, bigEndian);
-	data.replaceDoubleWord(pos + 0x08, header.sh_flags, bigEndian);
-	data.replaceDoubleWord(pos + 0x0C, header.sh_addr, bigEndian);
-	data.replaceDoubleWord(pos + 0x10, header.sh_offset, bigEndian);
-	data.replaceDoubleWord(pos + 0x14, header.sh_size, bigEndian);
-	data.replaceDoubleWord(pos + 0x18, header.sh_link, bigEndian);
-	data.replaceDoubleWord(pos + 0x1C, header.sh_info, bigEndian);
-	data.replaceDoubleWord(pos + 0x20, header.sh_addralign, bigEndian);
-	data.replaceDoubleWord(pos + 0x24, header.sh_entsize, bigEndian);
+	data.replaceDoubleWord(pos + 0x00, header.sh_name, endianness);
+	data.replaceDoubleWord(pos + 0x04, header.sh_type, endianness);
+	data.replaceDoubleWord(pos + 0x08, header.sh_flags, endianness);
+	data.replaceDoubleWord(pos + 0x0C, header.sh_addr, endianness);
+	data.replaceDoubleWord(pos + 0x10, header.sh_offset, endianness);
+	data.replaceDoubleWord(pos + 0x14, header.sh_size, endianness);
+	data.replaceDoubleWord(pos + 0x18, header.sh_link, endianness);
+	data.replaceDoubleWord(pos + 0x1C, header.sh_info, endianness);
+	data.replaceDoubleWord(pos + 0x20, header.sh_addralign, endianness);
+	data.replaceDoubleWord(pos + 0x24, header.sh_entsize, endianness);
 }
 
 // only called for segmentless sections
@@ -70,7 +70,7 @@ void ElfSection::setOffsetBase(int base)
 ElfSegment::ElfSegment(Elf32_Phdr header, ByteArray& segmentData): header(header)
 {
 	data = segmentData;
-	paddrSection = NULL;
+	paddrSection = nullptr;
 }
 
 bool ElfSegment::isSectionPartOf(ElfSection* section)
@@ -142,16 +142,16 @@ void ElfSegment::writeData(ByteArray& output)
 	output.append(data);
 }
 
-void ElfSegment::writeHeader(ByteArray& data, int pos, bool bigEndian)
+void ElfSegment::writeHeader(ByteArray& data, int pos, Endianness endianness)
 {
-	data.replaceDoubleWord(pos + 0x00, header.p_type, bigEndian);
-	data.replaceDoubleWord(pos + 0x04, header.p_offset, bigEndian);
-	data.replaceDoubleWord(pos + 0x08, header.p_vaddr, bigEndian);
-	data.replaceDoubleWord(pos + 0x0C, header.p_paddr, bigEndian);
-	data.replaceDoubleWord(pos + 0x10, header.p_filesz, bigEndian);
-	data.replaceDoubleWord(pos + 0x14, header.p_memsz, bigEndian);
-	data.replaceDoubleWord(pos + 0x18, header.p_flags, bigEndian);
-	data.replaceDoubleWord(pos + 0x1C, header.p_align, bigEndian);
+	data.replaceDoubleWord(pos + 0x00, header.p_type, endianness);
+	data.replaceDoubleWord(pos + 0x04, header.p_offset, endianness);
+	data.replaceDoubleWord(pos + 0x08, header.p_vaddr, endianness);
+	data.replaceDoubleWord(pos + 0x0C, header.p_paddr, endianness);
+	data.replaceDoubleWord(pos + 0x10, header.p_filesz, endianness);
+	data.replaceDoubleWord(pos + 0x14, header.p_memsz, endianness);
+	data.replaceDoubleWord(pos + 0x18, header.p_flags, endianness);
+	data.replaceDoubleWord(pos + 0x1C, header.p_align, endianness);
 }
 
 void ElfSegment::splitSections()
@@ -282,66 +282,66 @@ int ElfFile::findSegmentlessSection(const std::string& name)
 void ElfFile::loadElfHeader()
 {
 	memcpy(fileHeader.e_ident, &fileData[0], sizeof(fileHeader.e_ident));
-	bool bigEndian = isBigEndian();
-	fileHeader.e_type = fileData.getWord(0x10, bigEndian);
-	fileHeader.e_machine = fileData.getWord(0x12, bigEndian);
-	fileHeader.e_version = fileData.getDoubleWord(0x14, bigEndian);
-	fileHeader.e_entry = fileData.getDoubleWord(0x18, bigEndian);
-	fileHeader.e_phoff = fileData.getDoubleWord(0x1C, bigEndian);
-	fileHeader.e_shoff = fileData.getDoubleWord(0x20, bigEndian);
-	fileHeader.e_flags = fileData.getDoubleWord(0x24, bigEndian);
-	fileHeader.e_ehsize = fileData.getWord(0x28, bigEndian);
-	fileHeader.e_phentsize = fileData.getWord(0x2A, bigEndian);
-	fileHeader.e_phnum = fileData.getWord(0x2C, bigEndian);
-	fileHeader.e_shentsize = fileData.getWord(0x2E, bigEndian);
-	fileHeader.e_shnum = fileData.getWord(0x30, bigEndian);
-	fileHeader.e_shstrndx = fileData.getWord(0x32, bigEndian);
+	Endianness endianness = getEndianness();
+	fileHeader.e_type = fileData.getWord(0x10, endianness);
+	fileHeader.e_machine = fileData.getWord(0x12, endianness);
+	fileHeader.e_version = fileData.getDoubleWord(0x14, endianness);
+	fileHeader.e_entry = fileData.getDoubleWord(0x18, endianness);
+	fileHeader.e_phoff = fileData.getDoubleWord(0x1C, endianness);
+	fileHeader.e_shoff = fileData.getDoubleWord(0x20, endianness);
+	fileHeader.e_flags = fileData.getDoubleWord(0x24, endianness);
+	fileHeader.e_ehsize = fileData.getWord(0x28, endianness);
+	fileHeader.e_phentsize = fileData.getWord(0x2A, endianness);
+	fileHeader.e_phnum = fileData.getWord(0x2C, endianness);
+	fileHeader.e_shentsize = fileData.getWord(0x2E, endianness);
+	fileHeader.e_shnum = fileData.getWord(0x30, endianness);
+	fileHeader.e_shstrndx = fileData.getWord(0x32, endianness);
 }
 
-void ElfFile::writeHeader(ByteArray& data, int pos, bool bigEndian)
+void ElfFile::writeHeader(ByteArray& data, int pos, Endianness endianness)
 {
 	memcpy(&fileData[0], fileHeader.e_ident, sizeof(fileHeader.e_ident));
-	data.replaceWord(pos + 0x10, fileHeader.e_type, bigEndian);
-	data.replaceWord(pos + 0x12, fileHeader.e_machine, bigEndian);
-	data.replaceDoubleWord(pos + 0x14, fileHeader.e_version, bigEndian);
-	data.replaceDoubleWord(pos + 0x18, fileHeader.e_entry, bigEndian);
-	data.replaceDoubleWord(pos + 0x1C, fileHeader.e_phoff, bigEndian);
-	data.replaceDoubleWord(pos + 0x20, fileHeader.e_shoff, bigEndian);
-	data.replaceDoubleWord(pos + 0x24, fileHeader.e_flags, bigEndian);
-	data.replaceWord(pos + 0x28, fileHeader.e_ehsize, bigEndian);
-	data.replaceWord(pos + 0x2A, fileHeader.e_phentsize, bigEndian);
-	data.replaceWord(pos + 0x2C, fileHeader.e_phnum, bigEndian);
-	data.replaceWord(pos + 0x2E, fileHeader.e_shentsize, bigEndian);
-	data.replaceWord(pos + 0x30, fileHeader.e_shnum, bigEndian);
-	data.replaceWord(pos + 0x32, fileHeader.e_shstrndx, bigEndian);
+	data.replaceWord(pos + 0x10, fileHeader.e_type, endianness);
+	data.replaceWord(pos + 0x12, fileHeader.e_machine, endianness);
+	data.replaceDoubleWord(pos + 0x14, fileHeader.e_version, endianness);
+	data.replaceDoubleWord(pos + 0x18, fileHeader.e_entry, endianness);
+	data.replaceDoubleWord(pos + 0x1C, fileHeader.e_phoff, endianness);
+	data.replaceDoubleWord(pos + 0x20, fileHeader.e_shoff, endianness);
+	data.replaceDoubleWord(pos + 0x24, fileHeader.e_flags, endianness);
+	data.replaceWord(pos + 0x28, fileHeader.e_ehsize, endianness);
+	data.replaceWord(pos + 0x2A, fileHeader.e_phentsize, endianness);
+	data.replaceWord(pos + 0x2C, fileHeader.e_phnum, endianness);
+	data.replaceWord(pos + 0x2E, fileHeader.e_shentsize, endianness);
+	data.replaceWord(pos + 0x30, fileHeader.e_shnum, endianness);
+	data.replaceWord(pos + 0x32, fileHeader.e_shstrndx, endianness);
 }
 
 void ElfFile::loadProgramHeader(Elf32_Phdr& header, ByteArray& data, int pos)
 {
-	bool bigEndian = isBigEndian();
-	header.p_type   = data.getDoubleWord(pos + 0x00, bigEndian);
-	header.p_offset = data.getDoubleWord(pos + 0x04, bigEndian);
-	header.p_vaddr  = data.getDoubleWord(pos + 0x08, bigEndian);
-	header.p_paddr  = data.getDoubleWord(pos + 0x0C, bigEndian);
-	header.p_filesz = data.getDoubleWord(pos + 0x10, bigEndian);
-	header.p_memsz  = data.getDoubleWord(pos + 0x14, bigEndian);
-	header.p_flags  = data.getDoubleWord(pos + 0x18, bigEndian);
-	header.p_align  = data.getDoubleWord(pos + 0x1C, bigEndian);
+	Endianness endianness = getEndianness();
+	header.p_type   = data.getDoubleWord(pos + 0x00, endianness);
+	header.p_offset = data.getDoubleWord(pos + 0x04, endianness);
+	header.p_vaddr  = data.getDoubleWord(pos + 0x08, endianness);
+	header.p_paddr  = data.getDoubleWord(pos + 0x0C, endianness);
+	header.p_filesz = data.getDoubleWord(pos + 0x10, endianness);
+	header.p_memsz  = data.getDoubleWord(pos + 0x14, endianness);
+	header.p_flags  = data.getDoubleWord(pos + 0x18, endianness);
+	header.p_align  = data.getDoubleWord(pos + 0x1C, endianness);
 }
 
 void ElfFile::loadSectionHeader(Elf32_Shdr& header, ByteArray& data, int pos)
 {
-	bool bigEndian = isBigEndian();
-	header.sh_name      = data.getDoubleWord(pos + 0x00, bigEndian);
-	header.sh_type      = data.getDoubleWord(pos + 0x04, bigEndian);
-	header.sh_flags     = data.getDoubleWord(pos + 0x08, bigEndian);
-	header.sh_addr      = data.getDoubleWord(pos + 0x0C, bigEndian);
-	header.sh_offset    = data.getDoubleWord(pos + 0x10, bigEndian);
-	header.sh_size      = data.getDoubleWord(pos + 0x14, bigEndian);
-	header.sh_link      = data.getDoubleWord(pos + 0x18, bigEndian);
-	header.sh_info      = data.getDoubleWord(pos + 0x1C, bigEndian);
-	header.sh_addralign = data.getDoubleWord(pos + 0x20, bigEndian);
-	header.sh_entsize   = data.getDoubleWord(pos + 0x24, bigEndian);
+	Endianness endianness = getEndianness();
+	header.sh_name      = data.getDoubleWord(pos + 0x00, endianness);
+	header.sh_type      = data.getDoubleWord(pos + 0x04, endianness);
+	header.sh_flags     = data.getDoubleWord(pos + 0x08, endianness);
+	header.sh_addr      = data.getDoubleWord(pos + 0x0C, endianness);
+	header.sh_offset    = data.getDoubleWord(pos + 0x10, endianness);
+	header.sh_size      = data.getDoubleWord(pos + 0x14, endianness);
+	header.sh_link      = data.getDoubleWord(pos + 0x18, endianness);
+	header.sh_info      = data.getDoubleWord(pos + 0x1C, endianness);
+	header.sh_addralign = data.getDoubleWord(pos + 0x20, endianness);
+	header.sh_entsize   = data.getDoubleWord(pos + 0x24, endianness);
 }
 
 bool ElfFile::load(const std::wstring& fileName, bool sort)
@@ -357,8 +357,8 @@ bool ElfFile::load(ByteArray& data, bool sort)
 	fileData = data;
 
 	loadElfHeader();
-	symTab = NULL;
-	strTab = NULL;
+	symTab = nullptr;
+	strTab = nullptr;
 
 	// load segments
 	for (size_t i = 0; i < fileHeader.e_phnum; i++)
@@ -385,7 +385,7 @@ bool ElfFile::load(ByteArray& data, bool sort)
 		sections.push_back(section);
 
 		// check if the section belongs to a segment
-		ElfSegment* owner = NULL;
+		ElfSegment* owner = nullptr;
 		for (int k = 0; k < (int)segments.size(); k++)
 		{
 			if (segments[k]->isSectionPartOf(section))
@@ -395,7 +395,7 @@ bool ElfFile::load(ByteArray& data, bool sort)
 			}
 		}
 
-		if (owner != NULL)
+		if (owner != nullptr)
 		{
 			owner->addSection(section);
 		} else {
@@ -475,18 +475,18 @@ void ElfFile::save(const std::wstring&fileName)
 	}
 
 	// copy data to the tables
-	bool bigEndian = isBigEndian();
-	writeHeader(fileData, 0, bigEndian);
+	Endianness endianness = getEndianness();
+	writeHeader(fileData, 0, endianness);
 	for (size_t i = 0; i < segments.size(); i++)
 	{
 		int pos = fileHeader.e_phoff+i*fileHeader.e_phentsize;
-		segments[i]->writeHeader(fileData, pos, bigEndian);
+		segments[i]->writeHeader(fileData, pos, endianness);
 	}
 	
 	for (size_t i = 0; i < sections.size(); i++)
 	{
 		int pos = fileHeader.e_shoff+i*fileHeader.e_shentsize;
-		sections[i]->writeHeader(fileData, pos, bigEndian);
+		sections[i]->writeHeader(fileData, pos, endianness);
 	}
 
 	fileData.toFile(fileName);
@@ -494,7 +494,7 @@ void ElfFile::save(const std::wstring&fileName)
 
 int ElfFile::getSymbolCount()
 {
-	if (symTab == NULL)
+	if (symTab == nullptr)
 		return 0;
 
 	return symTab->getSize()/sizeof(Elf32_Sym);
@@ -502,26 +502,26 @@ int ElfFile::getSymbolCount()
 
 bool ElfFile::getSymbol(Elf32_Sym& symbol, size_t index)
 {
-	if (symTab == NULL)
+	if (symTab == nullptr)
 		return false;
 
 	ByteArray &data = symTab->getData();
 	int pos = index*sizeof(Elf32_Sym);
-	bool bigEndian = isBigEndian();
-	symbol.st_name  = data.getDoubleWord(pos + 0x00, bigEndian);
-	symbol.st_value = data.getDoubleWord(pos + 0x04, bigEndian);
-	symbol.st_size  = data.getDoubleWord(pos + 0x08, bigEndian);
+	Endianness endianness = getEndianness();
+	symbol.st_name  = data.getDoubleWord(pos + 0x00, endianness);
+	symbol.st_value = data.getDoubleWord(pos + 0x04, endianness);
+	symbol.st_size  = data.getDoubleWord(pos + 0x08, endianness);
 	symbol.st_info  = data[pos + 0x0C];
 	symbol.st_other = data[pos + 0x0D];
-	symbol.st_shndx = data.getWord(pos + 0x0E, bigEndian);
+	symbol.st_shndx = data.getWord(pos + 0x0E, endianness);
 
 	return true;
 }
 
 const char* ElfFile::getStrTableString(size_t pos)
 {
-	if (strTab == NULL)
-		return NULL;
+	if (strTab == nullptr)
+		return nullptr;
 	
 	return (const char*) &strTab->getData()[pos];
 }

--- a/Core/ELF/ElfFile.h
+++ b/Core/ELF/ElfFile.h
@@ -18,7 +18,11 @@ public:
 	void save(const std::wstring&fileName);
 
 	Elf32_Half getType() { return fileHeader.e_type; };
-	bool isBigEndian() { return (fileHeader.e_ident[EI_DATA] == ELFDATA2MSB); }
+	Elf32_Half getMachine() { return fileHeader.e_machine; };
+	Endianness getEndianness()
+	{
+		return fileHeader.e_ident[EI_DATA] == ELFDATA2MSB ? Endianness::Big : Endianness::Little;
+	}
 	size_t getSegmentCount() { return segments.size(); };
 	ElfSegment* getSegment(size_t index) { return segments[index]; };
 
@@ -32,7 +36,7 @@ public:
 	const char* getStrTableString(size_t pos);
 private:
 	void loadElfHeader();
-	void writeHeader(ByteArray& data, int pos, bool bigEndian);
+	void writeHeader(ByteArray& data, int pos, Endianness endianness);
 	void loadProgramHeader(Elf32_Phdr& header, ByteArray& data, int pos);
 	void loadSectionHeader(Elf32_Shdr& header, ByteArray& data, int pos);
 	void loadSectionNames();
@@ -58,8 +62,8 @@ public:
 	const std::string& getName() { return name; };
 	void setData(ByteArray& data) { this->data = data; };
 	void setOwner(ElfSegment* segment);
-	bool hasOwner() { return owner != NULL; };
-	void writeHeader(ByteArray& data, int pos, bool bigEndian);
+	bool hasOwner() { return owner != nullptr; };
+	void writeHeader(ByteArray& data, int pos, Endianness endianness);
 	void writeData(ByteArray& output);
 	void setOffsetBase(int base);
 	ByteArray& getData() { return data; };
@@ -90,7 +94,7 @@ public:
 	Elf32_Word getType() { return header.p_type; };
 	Elf32_Addr getVirtualAddress() { return header.p_vaddr; };
 	size_t getSectionCount() { return sections.size(); };
-	void writeHeader(ByteArray& data, int pos, bool bigEndian);
+	void writeHeader(ByteArray& data, int pos, Endianness endianness);
 	void writeData(ByteArray& output);
 	void splitSections();
 

--- a/Core/ELF/ElfRelocator.h
+++ b/Core/ELF/ElfRelocator.h
@@ -14,12 +14,15 @@ class Parser;
 class IElfRelocator
 {
 public:
-	virtual ~IElfRelocator() { };
+	virtual ~IElfRelocator() {};
+	virtual int expectedMachine() const = 0;
 	virtual bool isDummyRelocationType(int type) const { return false; }
 	virtual bool relocateOpcode(int type, RelocationData& data) = 0;
 	virtual void setSymbolAddress(RelocationData& data, int64_t symbolAddress, int symbolType) = 0;
+
 	virtual CAssemblerCommand* generateCtorStub(std::vector<ElfRelocatorCtor>& ctors) { return nullptr; }
 };
+
 
 class Label;
 
@@ -62,10 +65,10 @@ public:
 	const ByteArray& getData() const { return outputData; };
 private:
 	bool relocateFile(ElfRelocatorFile& file, int64_t& relocationAddress);
-	void loadRelocation(Elf32_Rel& rel, ByteArray& data, int offset, bool bigEndian);
+	void loadRelocation(Elf32_Rel& rel, ByteArray& data, int offset, Endianness endianness);
 
 	ByteArray outputData;
-	IElfRelocator* relocator;
+	std::unique_ptr<IElfRelocator> relocator;
 	std::vector<ElfRelocatorFile> files;
 	std::vector<ElfRelocatorCtor> ctors;
 	bool dataChanged;

--- a/Core/ELF/ElfTypes.h
+++ b/Core/ELF/ElfTypes.h
@@ -19,13 +19,8 @@ enum ElfType
 enum ElfMachine
 {
 	EM_NONE  =0,
-	EM_M32   =1,
-	EM_SPARC =2,
-	EM_386   =3,
-	EM_68K   =4,
-	EM_88K   =5,
-	EM_860   =7,
-	EM_MIPS  =8
+	EM_MIPS  =8,
+	EM_ARM   =40,
 };
 
 // File version

--- a/Core/Expression.cpp
+++ b/Core/Expression.cpp
@@ -541,7 +541,7 @@ ExpressionValue ExpressionInternal::executeFunctionCall()
 	auto it = expressionFunctions.find(strValue);
 	if (it == expressionFunctions.end())
 	{
-		auto archExpressionFunctions = Arch->getExpressionFunctions();
+		auto& archExpressionFunctions = Arch->getExpressionFunctions();
 		it = archExpressionFunctions.find(strValue);
 		if (it == archExpressionFunctions.end())
 		{

--- a/Core/FileManager.h
+++ b/Core/FileManager.h
@@ -3,8 +3,6 @@
 #include "../Util/FileClasses.h"
 #include "SymbolData.h"
 
-enum class Endianness { Big, Little };
-
 class AssemblerFile
 {
 public:

--- a/Core/SymbolTable.h
+++ b/Core/SymbolTable.h
@@ -15,7 +15,7 @@ bool operator<(SymbolKey const& lhs, SymbolKey const& rhs);
 class Label
 {
 public:
-	Label(std::wstring name): name(name), defined(false),info(0),data(false),updateInfo(true) { };
+	Label(std::wstring name): name(name),defined(false),data(false),updateInfo(true),info(0) { };
 	const std::wstring getName() { return name; };
 	void setOriginalName(const std::wstring& name) { originalName = name; }
 	const std::wstring getOriginalName() { return originalName.empty() ? name : originalName; }
@@ -36,8 +36,8 @@ private:
 	int64_t value;
 	bool defined;
 	bool data;
-	int info;
 	bool updateInfo;
+	int info;
 	int section;
 };
 

--- a/Util/ByteArray.h
+++ b/Util/ByteArray.h
@@ -7,6 +7,9 @@ typedef intptr_t ssize_t;
 #endif
 
 typedef unsigned char byte;
+
+enum class Endianness { Big, Little };
+
 class ByteArray
 {
 public:
@@ -26,12 +29,12 @@ public:
 	void reserveBytes(size_t count, byte value = 0);
 	void alignSize(size_t alignment);
 
-	int getWord(size_t pos, bool bigEndian = false) const
+	int getWord(size_t pos, Endianness endianness = Endianness::Little) const
 	{
 		if (pos+1 >= this->size()) return -1;
 		unsigned char* d = (unsigned char*) this->data();
 
-		if (bigEndian == false)
+		if (endianness == Endianness::Little)
 		{
 			return d[pos+0] | (d[pos+1] << 8);
 		} else {
@@ -39,12 +42,12 @@ public:
 		}
 	}
 
-	int getDoubleWord(size_t pos, bool bigEndian = false) const
+	int getDoubleWord(size_t pos, Endianness endianness = Endianness::Little) const
 	{
 		if (pos+3 >= this->size()) return -1;
 		unsigned char* d = (unsigned char*) this->data();
 
-		if (bigEndian == false)
+		if (endianness == Endianness::Little)
 		{
 			return d[pos+0] | (d[pos+1] << 8) | (d[pos+2] << 16) | (d[pos+3] << 24);
 		} else {
@@ -52,12 +55,12 @@ public:
 		}
 	}
 	
-	void replaceWord(size_t pos, unsigned int w, bool bigEndian = false)
+	void replaceWord(size_t pos, unsigned int w, Endianness endianness = Endianness::Little)
 	{
 		if (pos+1 >= this->size()) return;
 		unsigned char* d = (unsigned char*) this->data();
 
-		if (bigEndian == false)
+		if (endianness == Endianness::Little)
 		{
 			d[pos+0] = w & 0xFF;
 			d[pos+1] = (w >> 8) & 0xFF;
@@ -67,12 +70,12 @@ public:
 		}
 	}
 
-	void replaceDoubleWord(size_t pos, unsigned int w, bool bigEndian = false)
+	void replaceDoubleWord(size_t pos, unsigned int w, Endianness endianness = Endianness::Little)
 	{
 		if (pos+3 >= this->size()) return;
 		unsigned char* d = (unsigned char*) this->data();
 		
-		if (bigEndian == false)
+		if (endianness == Endianness::Little)
 		{
 			d[pos+0] = w & 0xFF;
 			d[pos+1] = (w >> 8) & 0xFF;

--- a/libarmips.vcxproj
+++ b/libarmips.vcxproj
@@ -217,10 +217,10 @@
   <ItemGroup>
     <ClCompile Include="Archs\Architecture.cpp" />
     <ClCompile Include="Archs\ARM\Arm.cpp" />
+    <ClCompile Include="Archs\ARM\ArmElfRelocator.cpp" />
     <ClCompile Include="Archs\ARM\ArmExpressionFunctions.cpp" />
     <ClCompile Include="Archs\ARM\ArmOpcodes.cpp" />
     <ClCompile Include="Archs\ARM\ArmParser.cpp" />
-    <ClCompile Include="Archs\ARM\ArmRelocator.cpp" />
     <ClCompile Include="Archs\ARM\CArmInstruction.cpp" />
     <ClCompile Include="Archs\ARM\CThumbInstruction.cpp" />
     <ClCompile Include="Archs\ARM\Pool.cpp" />
@@ -228,6 +228,7 @@
     <ClCompile Include="Archs\MIPS\CMipsInstruction.cpp" />
     <ClCompile Include="Archs\MIPS\Mips.cpp" />
     <ClCompile Include="Archs\MIPS\MipsElfFile.cpp" />
+    <ClCompile Include="Archs\MIPS\MipsElfRelocator.cpp" />
     <ClCompile Include="Archs\MIPS\MipsExpressionFunctions.cpp" />
     <ClCompile Include="Archs\MIPS\MipsMacros.cpp" />
     <ClCompile Include="Archs\MIPS\MipsOpcodes.cpp" />
@@ -272,10 +273,10 @@
   <ItemGroup>
     <ClInclude Include="Archs\Architecture.h" />
     <ClInclude Include="Archs\ARM\Arm.h" />
+    <ClInclude Include="Archs\ARM\ArmElfRelocator.h" />
     <ClInclude Include="Archs\ARM\ArmExpressionFunctions.h" />
     <ClInclude Include="Archs\ARM\ArmOpcodes.h" />
     <ClInclude Include="Archs\ARM\ArmParser.h" />
-    <ClInclude Include="Archs\ARM\ArmRelocator.h" />
     <ClInclude Include="Archs\ARM\CArmInstruction.h" />
     <ClInclude Include="Archs\ARM\CThumbInstruction.h" />
     <ClInclude Include="Archs\ARM\Pool.h" />
@@ -283,6 +284,7 @@
     <ClInclude Include="Archs\MIPS\CMipsInstruction.h" />
     <ClInclude Include="Archs\MIPS\Mips.h" />
     <ClInclude Include="Archs\MIPS\MipsElfFile.h" />
+    <ClInclude Include="Archs\MIPS\MipsElfRelocator.h" />
     <ClInclude Include="Archs\MIPS\MipsExpressionFunctions.h" />
     <ClInclude Include="Archs\MIPS\MipsMacros.h" />
     <ClInclude Include="Archs\MIPS\MipsOpcodes.h" />

--- a/libarmips.vcxproj.filters
+++ b/libarmips.vcxproj.filters
@@ -39,13 +39,13 @@
     <ClCompile Include="Archs\ARM\Arm.cpp">
       <Filter>Archs\ARM</Filter>
     </ClCompile>
+    <ClCompile Include="Archs\ARM\ArmElfRelocator.cpp">
+      <Filter>Archs\ARM</Filter>
+    </ClCompile>
     <ClCompile Include="Archs\ARM\ArmExpressionFunctions.cpp">
       <Filter>Archs\ARM</Filter>
     </ClCompile>
     <ClCompile Include="Archs\ARM\ArmOpcodes.cpp">
-      <Filter>Archs\ARM</Filter>
-    </ClCompile>
-    <ClCompile Include="Archs\ARM\ArmRelocator.cpp">
       <Filter>Archs\ARM</Filter>
     </ClCompile>
     <ClCompile Include="Archs\ARM\CArmInstruction.cpp">
@@ -67,6 +67,9 @@
       <Filter>Archs\MIPS</Filter>
     </ClCompile>
     <ClCompile Include="Archs\MIPS\MipsElfFile.cpp">
+      <Filter>Archs\MIPS</Filter>
+    </ClCompile>
+    <ClCompile Include="Archs\MIPS\MipsElfRelocator.cpp">
       <Filter>Archs\MIPS</Filter>
     </ClCompile>
     <ClCompile Include="Archs\MIPS\MipsExpressionFunctions.cpp">
@@ -177,13 +180,13 @@
     <ClInclude Include="Archs\ARM\Arm.h">
       <Filter>Archs\ARM</Filter>
     </ClInclude>
+    <ClInclude Include="Archs\ARM\ArmElfRelocator.h">
+      <Filter>Archs\ARM</Filter>
+    </ClInclude>
     <ClInclude Include="Archs\ARM\ArmExpressionFunctions.h">
       <Filter>Archs\ARM</Filter>
     </ClInclude>
     <ClInclude Include="Archs\ARM\ArmOpcodes.h">
-      <Filter>Archs\ARM</Filter>
-    </ClInclude>
-    <ClInclude Include="Archs\ARM\ArmRelocator.h">
       <Filter>Archs\ARM</Filter>
     </ClInclude>
     <ClInclude Include="Archs\ARM\CArmInstruction.h">
@@ -205,6 +208,9 @@
       <Filter>Archs\MIPS</Filter>
     </ClInclude>
     <ClInclude Include="Archs\MIPS\MipsElfFile.h">
+      <Filter>Archs\MIPS</Filter>
+    </ClInclude>
+    <ClInclude Include="Archs\MIPS\MipsElfRelocator.h">
       <Filter>Archs\MIPS</Filter>
     </ClInclude>
     <ClInclude Include="Archs\MIPS\MipsExpressionFunctions.h">

--- a/stdafx.h
+++ b/stdafx.h
@@ -29,6 +29,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <memory>
 
 #include "ext/tinyformat/tinyformat.h"
 #define formatString tfm::format


### PR DESCRIPTION
- Check machine and endianness in ELF header
- Move MipsElfRelocator class to separate file
- Return unique_ptr in getElfRelocator methods

Fixes in separate commits:
- Fix -Wreorder warnings 
- Save reference to arch-specific ExpressionFunctionMap instead of copying 