### PR TITLE
Allow build on target Haiku

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,11 @@ project(armips)
 option(ARMIPS_REGEXP "Enable regexp expression functions" ON)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
+	if(${CMAKE_SYSTEM_NAME} MATCHES "Haiku")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread -std=c++11 -Wno-uninitialized")
+	else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11 -Wno-uninitialized")
+	endif()
 endif()
 
 if(MSVC)

--- a/Main/Tests.cpp
+++ b/Main/Tests.cpp
@@ -41,7 +41,14 @@ StringList TestRunner::listSubfolders(const std::wstring& dir)
 		auto elem = readdir(directory);
 		while (elem != NULL)
 		{
-			if(elem->d_type == DT_DIR)
+#if defined(__HAIKU__)
+			// dirent in Posix does not have a d_type
+			struct stat s;
+			stat(elem->d_name, &s);
+			if (s.st_mode & S_IFDIR)
+#else
+			if (elem->d_type == DT_DIR)
+#endif
 			{
 				std::wstring dirName = convertUtf8ToWString(elem->d_name);
 				if (dirName != L"." && dirName != L"..")

--- a/Main/Tests.h
+++ b/Main/Tests.h
@@ -1,6 +1,10 @@
 #pragma once
 #include "Util/Util.h"
 
+#if defined(__HAIKU__)
+#include <sys/stat.h>
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #endif


### PR DESCRIPTION
This allows building on Haiku. 

Haiku is an [open-source implementation of BeOS](https://www.haiku-os.org/about/) that adheres to several POSIX standards. I need armips in order to build the libretro core for [PPSPP](https://github.com/kwyxz/ppsspp) on Haiku.

Thank you for considering this commit!