### PR TITLE
Fix implicit base class conversions for unique_ptr

### DIFF
--- a/Archs/ARM/ArmParser.cpp
+++ b/Archs/ARM/ArmParser.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectivePool(Parser& parser, int flags)
 	seq->addCommand(make_unique<CDirectiveAlignFill>(4,CDirectiveAlignFill::Align));
 	seq->addCommand(make_unique<ArmPoolCommand>());
 
-	return seq;
+	return std::move(seq);
 }
 
 const wchar_t* msgTemplate =

--- a/Archs/MIPS/CMipsInstruction.cpp
+++ b/Archs/MIPS/CMipsInstruction.cpp
@@ -201,6 +201,9 @@ bool CMipsInstruction::Validate()
 			if (immediateData.secondary.type == MipsImmediateType::Ins)
 				immediateData.secondary.value += immediateData.primary.value;
 			break;
+		case MipsImmediateType::Cop2BranchType:
+		default:
+			break;
 		}
 	}
 
@@ -291,6 +294,9 @@ void CMipsInstruction::encodeNormal() const
 	case MipsImmediateType::ImmediateHalfFloat:
 		encoding |= immediateData.primary.value;
 		break;
+	default:
+		// TODO: Assert?
+		break;
 	}
 
 	switch (immediateData.secondary.type)
@@ -304,6 +310,9 @@ void CMipsInstruction::encodeNormal() const
 		break;
 	case MipsImmediateType::Cop2BranchType:
 		encoding |= immediateData.secondary.value << 18;
+		break;
+	default:
+		// TODO: Assert?
 		break;
 	}
 
@@ -340,6 +349,9 @@ void CMipsInstruction::encodeVfpu() const
 		break;
 	case MipsImmediateType::Immediate7:
 		encoding |= immediateData.primary.value << 0;
+		break;
+	default:
+		// TODO: Assert?
 		break;
 	}
 

--- a/Commands/CDirectiveConditional.cpp
+++ b/Commands/CDirectiveConditional.cpp
@@ -55,6 +55,8 @@ bool CDirectiveConditional::evaluate()
 		return label->isDefined();
 	case ConditionType::IFNDEF:
 		return !label->isDefined();
+	default:
+		break;
 	}
 			
 	Logger::queueError(Logger::Error,L"Invalid conditional type");

--- a/Commands/CDirectiveData.cpp
+++ b/Commands/CDirectiveData.cpp
@@ -123,6 +123,8 @@ size_t CDirectiveData::getUnitSize() const
 	case EncodingMode::U64:
 	case EncodingMode::Double:
 		return 8;
+	case EncodingMode::Invalid:
+		break;
 	}
 
 	return 0;
@@ -143,6 +145,8 @@ size_t CDirectiveData::getDataSize() const
 	case EncodingMode::Float:
 	case EncodingMode::Double:
 		return normalData.size()*getUnitSize();
+	case EncodingMode::Invalid:
+		break;
 	}
 
 	return 0;
@@ -366,6 +370,9 @@ void CDirectiveData::Encode() const
 			g_fileManager->writeU64((uint64_t)value);
 		}
 		break;
+	case EncodingMode::Invalid:
+		// TODO: Assert?
+		break;
 	}
 }
 
@@ -421,6 +428,9 @@ void CDirectiveData::writeTempData(TempData& tempData) const
 			str += swprintf(str,20,L"0x%16llX,",(uint64_t)normalData[i]);
 		}
 		break;
+	case EncodingMode::Invalid:
+		// TODO: Assert?
+		break;
 	}
 
 	*(str-1) = 0;
@@ -450,6 +460,9 @@ void CDirectiveData::writeSymData(SymbolData& symData) const
 	case EncodingMode::U64:
 	case EncodingMode::Double:
 		symData.addData(position,getDataSize(),SymbolData::Data64);
+		break;
+	case EncodingMode::Invalid:
+		// TODO: Assert?
 		break;
 	}
 }

--- a/Commands/CDirectiveFile.cpp
+++ b/Commands/CDirectiveFile.cpp
@@ -70,6 +70,8 @@ bool CDirectiveFile::Validate()
 		closeFile = g_fileManager->getOpenFile();
 		g_fileManager->closeFile();
 		return false;
+	case Type::Invalid:
+		break;
 	}
 	
 	return false;
@@ -86,6 +88,9 @@ void CDirectiveFile::Encode() const
 		break;
 	case Type::Close:
 		g_fileManager->closeFile();
+		break;
+	case Type::Invalid:
+		// TODO: Assert?
 		break;
 	}
 }
@@ -109,6 +114,9 @@ void CDirectiveFile::writeTempData(TempData& tempData) const
 	case Type::Close:
 		str = L".close";
 		break;
+	case Type::Invalid:
+		// TODO: Assert?
+		break;
 	}
 
 	tempData.writeLine(virtualAddress,str);
@@ -126,6 +134,9 @@ void CDirectiveFile::writeSymData(SymbolData& symData) const
 	case Type::Close:
 		if (closeFile)
 			closeFile->endSymData(symData);
+		break;
+	case Type::Invalid:
+		// TODO: Assert?
 		break;
 	}
 }

--- a/Core/ELF/ElfRelocator.cpp
+++ b/Core/ELF/ElfRelocator.cpp
@@ -270,7 +270,7 @@ std::unique_ptr<CAssemblerCommand> ElfRelocator::generateCtor(const std::wstring
 
 	auto func = ::make_unique<CDirectiveFunction>(ctorName,ctorName);
 	func->setContent(std::move(content));
-	return func;
+	return std::move(func);
 }
 
 void ElfRelocator::loadRelocation(Elf32_Rel& rel, ByteArray& data, int offset, Endianness endianness)

--- a/Core/Expression.cpp
+++ b/Core/Expression.cpp
@@ -88,6 +88,8 @@ ExpressionValue ExpressionValue::operator-(const ExpressionValue& other) const
 		result.type = ExpressionValueType::Float;
 		result.floatValue = floatValue - other.floatValue;
 		break;
+	default:
+		break;
 	}
 
 	return result;
@@ -113,6 +115,8 @@ ExpressionValue ExpressionValue::operator*(const ExpressionValue& other) const
 	case ExpressionValueCombination::FF:
 		result.type = ExpressionValueType::Float;
 		result.floatValue = floatValue * other.floatValue;
+		break;
+	default:
 		break;
 	}
 
@@ -151,6 +155,8 @@ ExpressionValue ExpressionValue::operator/(const ExpressionValue& other) const
 		result.type = ExpressionValueType::Float;
 		result.floatValue = floatValue / other.floatValue;
 		break;
+	default:
+		break;
 	}
 
 	return result;
@@ -175,6 +181,8 @@ ExpressionValue ExpressionValue::operator%(const ExpressionValue& other) const
 			return result;
 		}
 		result.intValue = intValue % other.intValue;
+		break;
+	default:
 		break;
 	}
 
@@ -216,6 +224,8 @@ ExpressionValue ExpressionValue::operator<<(const ExpressionValue& other) const
 		result.type = ExpressionValueType::Integer;
 		result.intValue = ((uint64_t) intValue) << other.intValue;
 		break;
+	default:
+		break;
 	}
 
 	return result;
@@ -229,6 +239,8 @@ ExpressionValue ExpressionValue::operator>>(const ExpressionValue& other) const
 	case ExpressionValueCombination::II:
 		result.type = ExpressionValueType::Integer;
 		result.intValue = ((uint64_t) intValue) >> other.intValue;
+		break;
+	default:
 		break;
 	}
 
@@ -247,6 +259,8 @@ bool ExpressionValue::operator<(const ExpressionValue& other) const
 		return intValue < other.floatValue;
 	case ExpressionValueCombination::FF:
 		return floatValue < other.floatValue;
+	default:
+		break;
 	}
 
 	return false;
@@ -264,6 +278,8 @@ bool ExpressionValue::operator<=(const ExpressionValue& other) const
 		return intValue <= other.floatValue;
 	case ExpressionValueCombination::FF:
 		return floatValue <= other.floatValue;
+	default:
+		break;
 	}
 
 	return false;
@@ -320,6 +336,8 @@ ExpressionValue ExpressionValue::operator&(const ExpressionValue& other) const
 		result.type = ExpressionValueType::Integer;
 		result.intValue = intValue & other.intValue;
 		break;
+	default:
+		break;
 	}
 
 	return result;
@@ -333,6 +351,8 @@ ExpressionValue ExpressionValue::operator|(const ExpressionValue& other) const
 	case ExpressionValueCombination::II:
 		result.type = ExpressionValueType::Integer;
 		result.intValue = intValue | other.intValue;
+		break;
+	default:
 		break;
 	}
 
@@ -358,6 +378,8 @@ ExpressionValue ExpressionValue::operator&&(const ExpressionValue& other) const
 	case ExpressionValueCombination::FF:
 		result.floatValue = floatValue && other.floatValue;
 		break;
+	default:
+		break;
 	}
 
 	return result;
@@ -382,6 +404,8 @@ ExpressionValue ExpressionValue::operator||(const ExpressionValue& other) const
 	case ExpressionValueCombination::FF:
 		result.floatValue = floatValue || other.floatValue;
 		break;
+	default:
+		break;
 	}
 
 	return result;
@@ -395,6 +419,8 @@ ExpressionValue ExpressionValue::operator^(const ExpressionValue& other) const
 	case ExpressionValueCombination::II:
 		result.type = ExpressionValueType::Integer;
 		result.intValue = intValue ^ other.intValue;
+		break;
+	default:
 		break;
 	}
 
@@ -439,6 +465,8 @@ ExpressionInternal::ExpressionInternal(const std::wstring& value, OperatorType t
 		section = Global.Section;
 		break;
 	case OperatorType::String:
+		break;
+	default:
 		break;
 	}
 }
@@ -598,6 +626,8 @@ bool ExpressionInternal::simplify(bool inUnknownOrFalseBlock)
 	case OperatorType::FunctionCall:
 		if (isExpressionFunctionSafe(strValue, inUnknownOrFalseBlock) == false)
 			return false;
+		break;
+	default:
 		break;
 	}
 

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -257,6 +257,8 @@ ExpressionValue expFuncAbs(const std::wstring& funcName, const std::vector<Expre
 		result.intValue = parameters[0].intValue >= 0 ?
 			parameters[0].intValue : -parameters[0].intValue;
 		break;
+	default:
+		break;
 	}
 
 	return result;

--- a/Core/Misc.cpp
+++ b/Core/Misc.cpp
@@ -56,6 +56,8 @@ void Logger::setFlags(ErrorType type)
 		error = true;
 		fatalError = true;
 		break;
+	case Notice:
+		break;
 	}
 }
 

--- a/Parser/DirectivesParser.cpp
+++ b/Parser/DirectivesParser.cpp
@@ -240,7 +240,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveConditional(Parser& parser, int
 	const Token &next = parser.nextToken();
 	const std::wstring stringValue = next.getStringValue();
 
-	ConditionalResult elseResult = condResult;
+	ConditionalResult elseResult;
 	switch (condResult)
 	{
 	case ConditionalResult::True:
@@ -248,6 +248,9 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveConditional(Parser& parser, int
 		break;
 	case ConditionalResult::False:
 		elseResult = ConditionalResult::True;
+		break;
+	case ConditionalResult::Unknown:
+		elseResult = condResult;
 		break;
 	}
 

--- a/Parser/DirectivesParser.cpp
+++ b/Parser/DirectivesParser.cpp
@@ -41,10 +41,10 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveOpen(Parser& parser, int flags)
 			return nullptr;
 		
 		file->initCopy(inputName,outputName,memoryAddress);
-		return file;
+		return std::move(file);
 	} else {
 		file->initOpen(inputName,memoryAddress);
-		return file;
+		return std::move(file);
 	}
 }
 
@@ -65,14 +65,14 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveCreate(Parser& parser, int flag
 
 	auto file = make_unique<CDirectiveFile>();
 	file->initCreate(inputName,memoryAddress);
-	return file;
+	return std::move(file);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveClose(Parser& parser, int flags)
 {
 	auto file = make_unique<CDirectiveFile>();
 	file->initClose();
-	return file;
+	return std::move(file);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveIncbin(Parser& parser, int flags)
@@ -92,7 +92,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveIncbin(Parser& parser, int flag
 	if (list.size() == 3)
 		incbin->setSize(list[2]);
 
-	return incbin;
+	return std::move(incbin);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectivePosition(Parser& parser, int flags)
@@ -297,7 +297,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveConditional(Parser& parser, int
 		cond = make_unique<CDirectiveConditional>(type);
 
 	cond->setContent(std::move(ifBlock),std::move(elseBlock));
-	return cond;
+	return std::move(cond);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveTable(Parser& parser, int flags)
@@ -376,7 +376,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveData(Parser& parser, int flags)
 		break;
 	}
 	
-	return data;
+	return std::move(data);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveMipsArch(Parser& parser, int flags)
@@ -451,7 +451,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveArea(Parser& parser, int flags)
 	parser.eatToken();
 
 	area->setContent(std::move(content));
-	return area;
+	return std::move(area);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveErrorWarning(Parser& parser, int flags)
@@ -592,7 +592,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveFunction(Parser& parser, int fl
 	}
 
 	func->setContent(std::move(seq));
-	return func;
+	return std::move(func);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveMessage(Parser& parser, int flags)

--- a/Parser/ExpressionParser.cpp
+++ b/Parser/ExpressionParser.cpp
@@ -14,9 +14,6 @@ static ExpressionInternal* primaryExpression(Tokenizer& tokenizer)
 {
 	const Token &tok = tokenizer.peekToken();
 
-	if (tok.type == TokenType::Invalid)
-		return nullptr;
-
 	switch (tok.type)
 	{
 	case TokenType::Float:
@@ -38,16 +35,21 @@ static ExpressionInternal* primaryExpression(Tokenizer& tokenizer)
 		tokenizer.eatToken();
 		return new ExpressionInternal(tok.intValue);
 	case TokenType::LParen:
-		tokenizer.eatToken();
-		ExpressionInternal* exp = expression(tokenizer);
-			
-		if (tokenizer.nextToken().type != TokenType::RParen)
 		{
-			delete exp;
-			return nullptr;
-		}
+			tokenizer.eatToken();
+			ExpressionInternal* exp = expression(tokenizer);
 
-		return exp;
+			if (tokenizer.nextToken().type != TokenType::RParen)
+			{
+				delete exp;
+				return nullptr;
+			}
+
+			return exp;
+		}
+	case TokenType::Invalid:
+	default:
+		break;
 	}
 
 	return nullptr;
@@ -140,6 +142,8 @@ static ExpressionInternal* multiplicativeExpression(Tokenizer& tokenizer)
 		case TokenType::Mod:
 			op = OperatorType::Mod;
 			break;
+		default:
+			break;
 		}
 
 		if (op == OperatorType::Invalid)
@@ -177,6 +181,8 @@ static ExpressionInternal* additiveExpression(Tokenizer& tokenizer)
 		case TokenType::Minus:
 			op = OperatorType::Sub;
 			break;
+		default:
+			break;
 		}
 
 		if (op == OperatorType::Invalid)
@@ -213,6 +219,8 @@ static ExpressionInternal* shiftExpression(Tokenizer& tokenizer)
 			break;
 		case TokenType::RightShift:
 			op = OperatorType::RightShift;
+			break;
+		default:
 			break;
 		}
 
@@ -257,6 +265,8 @@ static ExpressionInternal* relationalExpression(Tokenizer& tokenizer)
 		case TokenType::GreaterEqual:
 			op = OperatorType::GreaterEqual;
 			break;
+		default:
+			break;
 		}
 
 		if (op == OperatorType::Invalid)
@@ -293,6 +303,8 @@ static ExpressionInternal* equalityExpression(Tokenizer& tokenizer)
 			break;
 		case TokenType::NotEqual:
 			op = OperatorType::NotEqual;
+			break;
+		default:
 			break;
 		}
 

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -155,7 +155,7 @@ std::unique_ptr<CAssemblerCommand> Parser::parseCommandSequence(wchar_t indicato
 		Logger::printError(Logger::Error, L"Unterminated command sequence, expected any of %s.", expected);
 	}
 
-	return sequence;
+	return std::move(sequence);
 }
 
 std::unique_ptr<CAssemblerCommand> Parser::parseFile(TextFile& file, bool virtualFile)

--- a/Util/FileClasses.cpp
+++ b/Util/FileClasses.cpp
@@ -921,6 +921,9 @@ wchar_t TextFile::readCharacter()
 		value = bufGetChar();
 		contentPos++;
 		break;
+	case GUESS:
+		errorText = formatString(L"Cannot read from GUESS encoding");
+		break;
 	}
 
 	// convert \r\n to \n


### PR DESCRIPTION
Needed to update in PPSSPP - otherwise it doesn't compile on several platforms, including Mac.

Also included some more warning fixes, I think it's warning clean now (at least with PPSSPP's warning options.)

-[Unknown]