### PR TITLE
Fix MINGW build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,3 +155,8 @@ if(WIN32)
 	target_link_libraries(armips-bin shlwapi)
 	target_link_libraries(armipstests shlwapi)
 endif(WIN32)
+
+if(MINGW)
+	target_link_libraries(armips-bin -lstdc++)
+	target_link_libraries(armipstests -lstdc++)
+endif(MINGW)


### PR DESCRIPTION
Very minor change, but I had to manually link to the standard library under MSYS MINGW for the build to complete successfully.