### PR TITLE
Add min() and max() expression functions.

### DIFF
--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -243,47 +243,41 @@ ExpressionValue expFuncFrac(const std::wstring& funcName, const std::vector<Expr
 ExpressionValue expFuncMin(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
 	ExpressionValue result;
-	double floatA, floatB;
-	int64_t intA, intB;
+	double floatMin, floatCur;
+	int64_t intMin, intCur;
 
 	bool isInt = true;
 
-	switch (parameters[0].type)
+	for (size_t i = 0; i < parameters.size(); i++)
 	{
-	case ExpressionValueType::Integer:
-		intA = parameters[0].intValue;
-		floatA = (double)parameters[0].intValue;
-		break;
-	case ExpressionValueType::Float:
-		floatA = parameters[0].floatValue;
-		isInt = false;
-		break;
-	default:
-		return result;
-	}
+		switch (parameters[i].type)
+		{
+		case ExpressionValueType::Integer:
+			intCur = parameters[i].intValue;
+			floatCur = (double)parameters[i].intValue;
+			break;
+		case ExpressionValueType::Float:
+			floatCur = parameters[i].floatValue;
+			isInt = false;
+			break;
+		default:
+			return result;
+		}
 
-	switch (parameters[1].type)
-	{
-	case ExpressionValueType::Integer:
-		intB = parameters[1].intValue;
-		floatB = (double)parameters[1].intValue;
-		break;
-	case ExpressionValueType::Float:
-		floatB = parameters[1].floatValue;
-		isInt = false;
-		break;
-	default:
-		return result;
+		if (i == 0 || intCur < intMin)
+			intMin = intCur;
+		if (i == 0 || floatCur < floatMin)
+			floatMin = floatCur;
 	}
 
 	if (isInt)
 	{
-		result.intValue = std::min(intA, intB);
+		result.intValue = intMin;
 		result.type = ExpressionValueType::Integer;
 	}
 	else
 	{
-		result.floatValue = std::min(floatA, floatB);
+		result.floatValue = floatMin;
 		result.type = ExpressionValueType::Float;
 	}
 
@@ -293,47 +287,41 @@ ExpressionValue expFuncMin(const std::wstring& funcName, const std::vector<Expre
 ExpressionValue expFuncMax(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
 	ExpressionValue result;
-	double floatA, floatB;
-	int64_t intA, intB;
+	double floatMax, floatCur;
+	int64_t intMax, intCur;
 
 	bool isInt = true;
 
-	switch (parameters[0].type)
+	for (size_t i = 0; i < parameters.size(); i++)
 	{
-	case ExpressionValueType::Integer:
-		intA = parameters[0].intValue;
-		floatA = (double)parameters[0].intValue;
-		break;
-	case ExpressionValueType::Float:
-		floatA = parameters[0].floatValue;
-		isInt = false;
-		break;
-	default:
-		return result;
-	}
+		switch (parameters[i].type)
+		{
+		case ExpressionValueType::Integer:
+			intCur = parameters[i].intValue;
+			floatCur = (double)parameters[i].intValue;
+			break;
+		case ExpressionValueType::Float:
+			floatCur = parameters[i].floatValue;
+			isInt = false;
+			break;
+		default:
+			return result;
+		}
 
-	switch (parameters[1].type)
-	{
-	case ExpressionValueType::Integer:
-		intB = parameters[1].intValue;
-		floatB = (double)parameters[1].intValue;
-		break;
-	case ExpressionValueType::Float:
-		floatB = parameters[1].floatValue;
-		isInt = false;
-		break;
-	default:
-		return result;
+		if (i == 0 || intCur > intMax)
+			intMax = intCur;
+		if (i == 0 || floatCur > floatMax)
+			floatMax = floatCur;
 	}
 
 	if (isInt)
 	{
-		result.intValue = std::max(intA, intB);
+		result.intValue = intMax;
 		result.type = ExpressionValueType::Integer;
 	}
 	else
 	{
-		result.floatValue = std::max(floatA, floatB);
+		result.floatValue = floatMax;
 		result.type = ExpressionValueType::Float;
 	}
 
@@ -605,8 +593,8 @@ const ExpressionFunctionMap expressionFunctions = {
 	{ L"frac",			{ &expFuncFrac,				1,	1,	ExpFuncSafety::Safe } },
 	{ L"abs",			{ &expFuncAbs,				1,	1,	ExpFuncSafety::Safe } },
 	{ L"round",			{ &expFuncRound,			1,	1,	ExpFuncSafety::Safe } },
-	{ L"min",			{ &expFuncMin,				2,	2,	ExpFuncSafety::Safe } },
-	{ L"max",			{ &expFuncMax,				2,	2,	ExpFuncSafety::Safe } },
+	{ L"min",			{ &expFuncMin,				1,	std::numeric_limits<std::size_t>::max(),	ExpFuncSafety::Safe } },
+	{ L"max",			{ &expFuncMax,				1,	std::numeric_limits<std::size_t>::max(),	ExpFuncSafety::Safe } },
 
 	{ L"strlen",		{ &expFuncStrlen,			1,	1,	ExpFuncSafety::Safe } },
 	{ L"substr",		{ &expFuncSubstr,			3,	3,	ExpFuncSafety::Safe } },

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -246,6 +246,8 @@ ExpressionValue expFuncMin(const std::wstring& funcName, const std::vector<Expre
 	double floatMin, floatCur;
 	int64_t intMin, intCur;
 
+	floatCur = floatMin = std::numeric_limits<double>::max();
+	intCur = intMin = std::numeric_limits<int64_t>::max();
 	bool isInt = true;
 
 	for (size_t i = 0; i < parameters.size(); i++)
@@ -264,9 +266,9 @@ ExpressionValue expFuncMin(const std::wstring& funcName, const std::vector<Expre
 			return result;
 		}
 
-		if (i == 0 || intCur < intMin)
+		if (intCur < intMin)
 			intMin = intCur;
-		if (i == 0 || floatCur < floatMin)
+		if (floatCur < floatMin)
 			floatMin = floatCur;
 	}
 
@@ -290,6 +292,8 @@ ExpressionValue expFuncMax(const std::wstring& funcName, const std::vector<Expre
 	double floatMax, floatCur;
 	int64_t intMax, intCur;
 
+	floatCur = floatMax = std::numeric_limits<double>::min();
+	intCur = intMax = std::numeric_limits<int64_t>::min();
 	bool isInt = true;
 
 	for (size_t i = 0; i < parameters.size(); i++)
@@ -308,9 +312,9 @@ ExpressionValue expFuncMax(const std::wstring& funcName, const std::vector<Expre
 			return result;
 		}
 
-		if (i == 0 || intCur > intMax)
+		if (intCur > intMax)
 			intMax = intCur;
-		if (i == 0 || floatCur > floatMax)
+		if (floatCur > floatMax)
 			floatMax = floatCur;
 	}
 
@@ -593,8 +597,8 @@ const ExpressionFunctionMap expressionFunctions = {
 	{ L"frac",			{ &expFuncFrac,				1,	1,	ExpFuncSafety::Safe } },
 	{ L"abs",			{ &expFuncAbs,				1,	1,	ExpFuncSafety::Safe } },
 	{ L"round",			{ &expFuncRound,			1,	1,	ExpFuncSafety::Safe } },
-	{ L"min",			{ &expFuncMin,				1,	std::numeric_limits<std::size_t>::max(),	ExpFuncSafety::Safe } },
-	{ L"max",			{ &expFuncMax,				1,	std::numeric_limits<std::size_t>::max(),	ExpFuncSafety::Safe } },
+	{ L"min",			{ &expFuncMin,				1,	std::numeric_limits<size_t>::max(),	ExpFuncSafety::Safe } },
+	{ L"max",			{ &expFuncMax,				1,	std::numeric_limits<size_t>::max(),	ExpFuncSafety::Safe } },
 
 	{ L"strlen",		{ &expFuncStrlen,			1,	1,	ExpFuncSafety::Safe } },
 	{ L"substr",		{ &expFuncSubstr,			3,	3,	ExpFuncSafety::Safe } },

--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -240,7 +240,105 @@ ExpressionValue expFuncFrac(const std::wstring& funcName, const std::vector<Expr
 	return result;
 }
 
+ExpressionValue expFuncMin(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	ExpressionValue result;
+	double floatA, floatB;
+	int64_t intA, intB;
 
+	bool isInt = true;
+
+	switch (parameters[0].type)
+	{
+	case ExpressionValueType::Integer:
+		intA = parameters[0].intValue;
+		floatA = (double)parameters[0].intValue;
+		break;
+	case ExpressionValueType::Float:
+		floatA = parameters[0].floatValue;
+		isInt = false;
+		break;
+	default:
+		return result;
+	}
+
+	switch (parameters[1].type)
+	{
+	case ExpressionValueType::Integer:
+		intB = parameters[1].intValue;
+		floatB = (double)parameters[1].intValue;
+		break;
+	case ExpressionValueType::Float:
+		floatB = parameters[1].floatValue;
+		isInt = false;
+		break;
+	default:
+		return result;
+	}
+
+	if (isInt)
+	{
+		result.intValue = std::min(intA, intB);
+		result.type = ExpressionValueType::Integer;
+	}
+	else
+	{
+		result.floatValue = std::min(floatA, floatB);
+		result.type = ExpressionValueType::Float;
+	}
+
+	return result;
+}
+
+ExpressionValue expFuncMax(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
+{
+	ExpressionValue result;
+	double floatA, floatB;
+	int64_t intA, intB;
+
+	bool isInt = true;
+
+	switch (parameters[0].type)
+	{
+	case ExpressionValueType::Integer:
+		intA = parameters[0].intValue;
+		floatA = (double)parameters[0].intValue;
+		break;
+	case ExpressionValueType::Float:
+		floatA = parameters[0].floatValue;
+		isInt = false;
+		break;
+	default:
+		return result;
+	}
+
+	switch (parameters[1].type)
+	{
+	case ExpressionValueType::Integer:
+		intB = parameters[1].intValue;
+		floatB = (double)parameters[1].intValue;
+		break;
+	case ExpressionValueType::Float:
+		floatB = parameters[1].floatValue;
+		isInt = false;
+		break;
+	default:
+		return result;
+	}
+
+	if (isInt)
+	{
+		result.intValue = std::max(intA, intB);
+		result.type = ExpressionValueType::Integer;
+	}
+	else
+	{
+		result.floatValue = std::max(floatA, floatB);
+		result.type = ExpressionValueType::Float;
+	}
+
+	return result;
+}
 
 ExpressionValue expFuncAbs(const std::wstring& funcName, const std::vector<ExpressionValue>& parameters)
 {
@@ -507,6 +605,8 @@ const ExpressionFunctionMap expressionFunctions = {
 	{ L"frac",			{ &expFuncFrac,				1,	1,	ExpFuncSafety::Safe } },
 	{ L"abs",			{ &expFuncAbs,				1,	1,	ExpFuncSafety::Safe } },
 	{ L"round",			{ &expFuncRound,			1,	1,	ExpFuncSafety::Safe } },
+	{ L"min",			{ &expFuncMin,				2,	2,	ExpFuncSafety::Safe } },
+	{ L"max",			{ &expFuncMax,				2,	2,	ExpFuncSafety::Safe } },
 
 	{ L"strlen",		{ &expFuncStrlen,			1,	1,	ExpFuncSafety::Safe } },
 	{ L"substr",		{ &expFuncSubstr,			3,	3,	ExpFuncSafety::Safe } },

--- a/Readme.md
+++ b/Readme.md
@@ -229,6 +229,8 @@ Below is a table of functions built into the assembler that can be used with the
 | `abs(val)` | absolute value of int or float `val` |
 | `hi(val)` | High half of 32-bit value `val`, adjusted for sign extension of low half (MIPS) |
 | `lo(val)` | Sign-extended low half of 32-bit value `val` (MIPS) |
+| `min(a, b)` | minimum of int or float `a` and `b`; result type is int if `a` and `b` are both int, float otherwise |
+| `max(a, b)` | maximum of int or float `a` and `b`; result type is int if `a` and `b` are both int, float otherwise |
 | `strlen(str)` | number of characters in `str` |
 | `substr(str, start, count)` | substring of `str` from `start`, length `count` |
 | `regex_match(source, regex)` | `1` if `regex` matched entire `source`, `0` otherwise|

--- a/Readme.md
+++ b/Readme.md
@@ -229,8 +229,8 @@ Below is a table of functions built into the assembler that can be used with the
 | `abs(val)` | absolute value of int or float `val` |
 | `hi(val)` | High half of 32-bit value `val`, adjusted for sign extension of low half (MIPS) |
 | `lo(val)` | Sign-extended low half of 32-bit value `val` (MIPS) |
-| `min(a, b)` | minimum of int or float `a` and `b`; result type is int if `a` and `b` are both int, float otherwise |
-| `max(a, b)` | maximum of int or float `a` and `b`; result type is int if `a` and `b` are both int, float otherwise |
+| `min(a, b, ...)` | minimum of int or float parameters `a`, `b`, ...; result type is int if all parameters are int, float otherwise |
+| `max(a, b, ...)` | maximum of int or float parameters `a`, `b`, ...; result type is int if all parameters are int, float otherwise |
 | `strlen(str)` | number of characters in `str` |
 | `substr(str, start, count)` | substring of `str` from `start`, length `count` |
 | `regex_match(source, regex)` | `1` if `regex` matched entire `source`, `0` otherwise|

--- a/Tests/Core/ExpressionFunctions/ExpressionFunctions.asm
+++ b/Tests/Core/ExpressionFunctions/ExpressionFunctions.asm
@@ -86,4 +86,17 @@ test1	defined,label1
 
 test3	readascii,fileA,4,4
 
+test1	max,1
+test2	max,1,2
+test3	max,1,2,3
+test3	max,1,2.5,4
+test1	min,1
+test2	min,1,2
+test3	min,1,2,3
+test3	min,1,2.5,4
+test2	max,-3,3
+test2	min,-3,3
+test2	max,-3.0,3.0
+test2	min,-3.0,3.0
+
 .close

--- a/Tests/Core/ExpressionFunctions/expected.txt
+++ b/Tests/Core/ExpressionFunctions/expected.txt
@@ -34,3 +34,15 @@ ExpressionFunctions.asm(81) notice: regex_extract("test123test","[0-9]+"): 123
 ExpressionFunctions.asm(84) notice: defined(label): 1
 ExpressionFunctions.asm(85) notice: defined(label1): 0
 ExpressionFunctions.asm(87) notice: readascii("file.bin",4,4): test
+ExpressionFunctions.asm(89) notice: max(1): 1
+ExpressionFunctions.asm(90) notice: max(1,2): 2
+ExpressionFunctions.asm(91) notice: max(1,2,3): 3
+ExpressionFunctions.asm(92) notice: max(1,2.5,4): 4.0000000000000000
+ExpressionFunctions.asm(93) notice: min(1): 1
+ExpressionFunctions.asm(94) notice: min(1,2): 1
+ExpressionFunctions.asm(95) notice: min(1,2,3): 1
+ExpressionFunctions.asm(96) notice: min(1,2.5,4): 1.0000000000000000
+ExpressionFunctions.asm(97) notice: max((-3),3): 3
+ExpressionFunctions.asm(98) notice: min((-3),3): -3
+ExpressionFunctions.asm(99) notice: max((-3),3): 3.0000000000000000
+ExpressionFunctions.asm(100) notice: min((-3),3): -3.0000000000000000


### PR DESCRIPTION
This adds `min()` and `max()` expression functions which take any number (min 1) of _int_ or _float_ parameters. The result type is _int_ if all parameters are _int_, otherwise the parameters are converted to _float_ and the result type is also _float_.

One potential use case would be to get the maximum size of a number of files so you could allocate a buffer that is just large enough to hold any of those files.