### PR TITLE
Fix initial negative headersizes

### DIFF
--- a/Core/FileManager.cpp
+++ b/Core/FileManager.cpp
@@ -166,11 +166,13 @@ bool GenericAssemblerFile::write(void* data, size_t length)
 
 bool GenericAssemblerFile::seekVirtual(int64_t virtualAddress)
 {
-	if (virtualAddress - headerSize < 0 || virtualAddress < 0)
+	if (virtualAddress - headerSize < 0)
 	{
-		Logger::queueError(Logger::Error,L"Seeking to invalid address");
+		Logger::queueError(Logger::Error,L"Seeking to virtual address with negative physical address");
 		return false;
 	}
+	if (virtualAddress < 0)
+		Logger::queueError(Logger::Warning,L"Seeking to negative virtual address");
 
 	this->virtualAddress = virtualAddress;
 	int64_t physicalAddress = virtualAddress-headerSize;
@@ -183,11 +185,13 @@ bool GenericAssemblerFile::seekVirtual(int64_t virtualAddress)
 
 bool GenericAssemblerFile::seekPhysical(int64_t physicalAddress)
 {
-	if (physicalAddress < 0 || physicalAddress + headerSize < 0)
+	if (physicalAddress < 0)
 	{
-		Logger::queueError(Logger::Error,L"Seeking to invalid address");
+		Logger::queueError(Logger::Error,L"Seeking to negative physical address");
 		return false;
 	}
+	if (physicalAddress + headerSize < 0)
+		Logger::queueError(Logger::Warning,L"Seeking to physical address with negative virtual address");
 
 	virtualAddress = physicalAddress+headerSize;
 


### PR DESCRIPTION
I'm using ARMIPS to generate some files where the game skips the first 4 bytes of the file when reading relative addresses (e.g. relative address 4 actually points to absolute address 8). This can be achieved by setting a headersize of -4 in ARMIPS. However, ARMIPS currently throws an error when you try to do this at the start of the file, because for some reason it checks whether 0-4 is a valid address, even though it just seeks to 0 anyway.

A workaround for this would be to start off with a headersize 0, make sure at least 4 bytes are written, and then setting .headersize -4. But I don't see a reason why this shouldn't be possible from the start as well.

This PR removes the `physicalAddress + headerSize < 0` check in GenericAssemblerFile::seekPhysical so that initial negative header sizes can work again. I think this error is being thrown erroneously in this situation.

A related PR for this is https://github.com/Kingcom/armips/pull/90 which removed support for initial header sizes by making ARMIPS seek to the start of a file upon opening/creating it, but this seems like more of a consequence rather than the intent, since it doesn't touch the seekPhysical() function at all. Rather, the check was added in https://github.com/Kingcom/armips/commit/a19efeff0b99eae59b0afdaf50222f9edf9c35cf which intended to _add_ support for negative headersizes.