### PR TITLE
Include labels defined on the command line in generated symfile.

### DIFF
--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -158,6 +158,10 @@ bool runArmips(ArmipsArguments& arguments)
 	}
 
 	Global.symbolTable.addLabels(arguments.labels);
+	for (const LabelDefinition& label : arguments.labels)
+	{
+		symData.addLabel(label.value, label.name);
+	}
 
 	if (Logger::hasError())
 		return false;


### PR DESCRIPTION
Fixes #148.

Not entirely sure if this would be the intended way of accomplishing it, but it works.