### PR TITLE
Fix -definelabel sign extend (fixes #158)

### DIFF
--- a/Core/Assembler.h
+++ b/Core/Assembler.h
@@ -12,7 +12,7 @@ enum class ArmipsMode { FILE, MEMORY };
 struct LabelDefinition
 {
 	std::wstring name;
-	int value;
+	int64_t value;
 };
 
 struct EquationDefinition


### PR DESCRIPTION
This should fix #158 by changing the `LabelDefinition` type from 32-bit to 64-bit.

Unfortunately, I can't add a proper test case this time, since there is currently no way to run tests with arbitrary arguments (e.g. `-definelabel`). But I've tested a few cases manually and it seems to work fine.