### PR TITLE
Preserve case of labels provided through -definelabel for -sym2

### DIFF
--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -160,7 +160,7 @@ bool runArmips(ArmipsArguments& settings)
 	Global.symbolTable.addLabels(settings.labels);
 	for (const LabelDefinition& label : settings.labels)
 	{
-		symData.addLabel(label.value, label.name);
+		symData.addLabel(label.value, label.originalName);
 	}
 
 	if (Logger::hasError())

--- a/Core/Assembler.h
+++ b/Core/Assembler.h
@@ -11,6 +11,7 @@ enum class ArmipsMode { FILE, MEMORY };
 
 struct LabelDefinition
 {
+	std::wstring originalName;
 	std::wstring name;
 	int64_t value;
 };

--- a/Core/SymbolTable.cpp
+++ b/Core/SymbolTable.cpp
@@ -185,6 +185,8 @@ void SymbolTable::addLabels(const std::vector<LabelDefinition>& labels)
 		if (label == nullptr)
 			continue;
 
+		label->setOriginalName(def.originalName);
+
 		if (isLocalSymbol(def.name) == false)
 			Global.Section++;
 

--- a/Main/CommandLineInterface.cpp
+++ b/Main/CommandLineInterface.cpp
@@ -94,14 +94,14 @@ static bool parseArguments(const StringList& arguments, ArmipsArguments& setting
 			{
 				LabelDefinition def;
 
-				def.name = arguments[argpos + 1];
+				def.originalName = arguments[argpos + 1];
+				def.name = def.originalName;
 				std::transform(def.name.begin(), def.name.end(), def.name.begin(), ::towlower);
 
 				int64_t value;
 				if (!stringToInt(arguments[argpos + 2], 0, arguments[argpos + 2].size(), value))
 				{
 					Logger::printError(Logger::Error, L"Invalid definelabel value '%s'\n", arguments[argpos + 2]);
-					printUsage(arguments[0]);
 					return false;
 				}
 				def.value = value;


### PR DESCRIPTION
As requested in the comments of #155, I extracted only the changes that preserve case of `-definelabel` labels for use by `-sym2`.

I also went ahead and deleted `-definelabel`'s `printUsage` call while I was there since sp1187 had previously mentioned it was superfluous.