### PR TITLE
Fix local labels not working after a .msg directive

### DIFF
--- a/Archs/ARM/ArmParser.cpp
+++ b/Archs/ARM/ArmParser.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveMsg(Parser& parser, int flags)
 		return nullptr;
 
 	return parser.parseTemplate(msgTemplate, {
-		{ L"%after%", Global.symbolTable.getUniqueLabelName() },
+		{ L"%after%", Global.symbolTable.getUniqueLabelName(true) },
 		{ L"%text%", text.toString() },
 		{ L"%alignment%", Arm.GetThumbMode() == true ? L"2" : L"4" }
 	});


### PR DESCRIPTION
Currently if you try to use a local label after a .msg directive like this
```
.gba
.create "test.bin", 0x00000000
start:
cmp r1,0x64
bne @@end
.msg "test"
@@end:
mov r15,r14
.close
```
it will say that `@@end` is an undefined label. This change has it generate a local label so it doesn't cause the local labels after it to become invalid.