### PR TITLE
Improve area warnings/errors and add option to show area stats

### DIFF
--- a/Archs/ARM/ArmParser.cpp
+++ b/Archs/ARM/ArmParser.cpp
@@ -761,9 +761,9 @@ std::unique_ptr<CThumbInstruction> ArmParser::parseThumbOpcode(Parser& parser)
 	}
 
 	if (paramFail == true)
-		parser.printError(token,L"THUMB parameter failure");
+		parser.printError(token,L"THUMB parameter failure in %S",stringValue);
 	else
-		parser.printError(token,L"Invalid THUMB opcode");
+		parser.printError(token,L"Invalid THUMB opcode: %S",stringValue);
 	
 	return nullptr;
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ add_library(armips STATIC
 	Core/ELF/ElfRelocator.h
 	Core/ELF/ElfFile.cpp
 	Core/ELF/ElfFile.h
+	Core/Allocations.cpp
+	Core/Allocations.h
 	Core/Assembler.cpp
 	Core/Assembler.h
 	Core/Common.cpp

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Commands/CDirectiveArea.h"
+#include "Core/Allocations.h"
 #include "Core/Common.h"
 #include "Core/FileManager.h"
 #include <algorithm>
@@ -8,6 +9,7 @@ CDirectiveArea::CDirectiveArea(Expression& size)
 {
 	this->areaSize = 0;
 	this->contentSize = 0;
+	this->position = 0;
 	this->fillValue = 0;
 
 	this->sizeExpression = size;
@@ -23,6 +25,7 @@ bool CDirectiveArea::Validate()
 {
 	int64_t oldAreaSize = areaSize;
 	int64_t oldContentSize = contentSize;
+	int64_t oldPosition = position;
 
 	position = g_fileManager->getVirtualAddress();
 
@@ -64,6 +67,11 @@ bool CDirectiveArea::Validate()
 
 	if (areaSize != oldAreaSize || contentSize != oldContentSize)
 		result = true;
+
+	if ((oldPosition != position || areaSize == 0) && oldAreaSize != 0)
+		Allocations::forgetArea(oldPosition, oldAreaSize);
+	if (areaSize != 0)
+		Allocations::setArea(position, areaSize, contentSize);
 
 	return result;
 }

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -56,7 +56,7 @@ bool CDirectiveArea::Validate()
 
 	if (areaSize < contentSize)
 	{
-		Logger::queueError(Logger::Error,L"Area overflowed");
+		Logger::queueError(Logger::Error, L"Area at %08x overflowed by %d bytes", position, contentSize - areaSize);
 	}
 
 	if (fillExpression.isLoaded())

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -71,7 +71,7 @@ bool CDirectiveArea::Validate()
 	if ((oldPosition != position || areaSize == 0) && oldAreaSize != 0)
 		Allocations::forgetArea(oldPosition, oldAreaSize);
 	if (areaSize != 0)
-		Allocations::setArea(position, areaSize, contentSize);
+		Allocations::setArea(position, areaSize, contentSize, fillExpression.isLoaded());
 
 	return result;
 }

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -68,10 +68,12 @@ bool CDirectiveArea::Validate()
 	if (areaSize != oldAreaSize || contentSize != oldContentSize)
 		result = true;
 
+	std::shared_ptr<AssemblerFile> file = g_fileManager->getOpenFile();
+	static_assert(sizeof(int64_t) >= sizeof(intptr_t), "Assumes pointers are <= 64 bit");
 	if ((oldPosition != position || areaSize == 0) && oldAreaSize != 0)
-		Allocations::forgetArea(oldPosition, oldAreaSize);
+		Allocations::forgetArea((int64_t)(intptr_t)file.get(), oldPosition, oldAreaSize);
 	if (areaSize != 0)
-		Allocations::setArea(position, areaSize, contentSize, fillExpression.isLoaded());
+		Allocations::setArea((int64_t)(intptr_t)file.get(), position, areaSize, contentSize, fillExpression.isLoaded());
 
 	return result;
 }

--- a/Core/Allocations.cpp
+++ b/Core/Allocations.cpp
@@ -1,0 +1,84 @@
+#include "stdafx.h"
+#include "Allocations.h"
+
+std::map<int64_t, Allocations::Usage> Allocations::allocations;
+
+void Allocations::clear()
+{
+	allocations.clear();
+}
+
+void Allocations::setArea(int64_t position, int64_t space, int64_t usage)
+{
+	allocations[position] = Usage{ space, usage };
+}
+
+void Allocations::forgetArea(int64_t position, int64_t space)
+{
+	auto it = allocations.find(position);
+	if (it != allocations.end() && it->second.space == space) {
+		allocations.erase(it);
+	}
+}
+
+AllocationStats Allocations::collectStats()
+{
+	AllocationStats stats{};
+
+	// Need to work out overlaps.
+	int64_t lastPosition = -1;
+	int64_t lastEndPosition = -1;
+	Usage lastUsage{};
+
+	auto applyUsage = [&stats](int64_t position, const Usage &usage)
+	{
+		if (usage.space > stats.largestSize)
+		{
+			stats.largestPosition = position;
+			stats.largestSize = usage.space;
+			stats.largestUsage = usage.usage;
+		}
+
+		if (usage.space - usage.usage > stats.largestFreeSize - stats.largestFreeUsage)
+		{
+			stats.largestFreePosition = position;
+			stats.largestFreeSize = usage.space;
+			stats.largestFreeUsage = usage.usage;
+		}
+
+		stats.totalSize += usage.space;
+		stats.totalUsage += usage.usage;
+	};
+
+	for (auto it : allocations)
+	{
+		if (it.first > lastPosition && it.first < lastEndPosition)
+		{
+			// Overlap, merge.
+			int64_t lastUsageEnd = lastPosition + lastUsage.usage;
+			int64_t newUsageEnd = it.first + it.second.usage;
+
+			if (lastUsageEnd >= it.first)
+				lastUsage.usage += newUsageEnd - lastUsageEnd;
+			else
+				lastUsage.usage += it.second.usage;
+
+			lastEndPosition = it.first + it.second.space;
+			lastUsage.space = lastEndPosition - lastPosition;
+
+			continue;
+		}
+
+		if (lastPosition != -1)
+			applyUsage(lastPosition, lastUsage);
+
+		lastPosition = it.first;
+		lastUsage = it.second;
+		lastEndPosition = it.first + it.second.space;
+	}
+
+	if (lastPosition != -1)
+		applyUsage(lastPosition, lastUsage);
+
+	return stats;
+}

--- a/Core/Allocations.h
+++ b/Core/Allocations.h
@@ -18,15 +18,17 @@ struct AllocationStats {
 class Allocations {
 public:
 	static void clear();
-	static void setArea(int64_t position, int64_t space, int64_t usage);
+	static void setArea(int64_t position, int64_t space, int64_t usage, bool usesFill);
 	static void forgetArea(int64_t position, int64_t space);
 
+	static void validateOverlap();
 	static AllocationStats collectStats();
 
 private:
 	struct Usage {
 		int64_t space;
 		int64_t usage;
+		bool usesFill;
 	};
 	static std::map<int64_t, Usage> allocations;
 };

--- a/Core/Allocations.h
+++ b/Core/Allocations.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <map>
+
+struct AllocationStats {
+	int64_t largestPosition;
+	int64_t largestSize;
+	int64_t largestUsage;
+
+	int64_t largestFreePosition;
+	int64_t largestFreeSize;
+	int64_t largestFreeUsage;
+
+	int64_t totalSize;
+	int64_t totalUsage;
+};
+
+class Allocations {
+public:
+	static void clear();
+	static void setArea(int64_t position, int64_t space, int64_t usage);
+	static void forgetArea(int64_t position, int64_t space);
+
+	static AllocationStats collectStats();
+
+private:
+	struct Usage {
+		int64_t space;
+		int64_t usage;
+	};
+	static std::map<int64_t, Usage> allocations;
+};

--- a/Core/Allocations.h
+++ b/Core/Allocations.h
@@ -18,17 +18,26 @@ struct AllocationStats {
 class Allocations {
 public:
 	static void clear();
-	static void setArea(int64_t position, int64_t space, int64_t usage, bool usesFill);
-	static void forgetArea(int64_t position, int64_t space);
+	static void setArea(int64_t fileID, int64_t position, int64_t space, int64_t usage, bool usesFill);
+	static void forgetArea(int64_t fileID, int64_t position, int64_t space);
 
 	static void validateOverlap();
 	static AllocationStats collectStats();
 
 private:
+	struct Key {
+		int64_t fileID;
+		int64_t position;
+
+		inline bool operator <(const Allocations::Key &other) const
+		{
+			return std::tie(fileID, position) < std::tie(other.fileID, other.position);
+		}
+	};
 	struct Usage {
 		int64_t space;
 		int64_t usage;
 		bool usesFill;
 	};
-	static std::map<int64_t, Usage> allocations;
+	static std::map<Key, Usage> allocations;
 };

--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -57,6 +57,8 @@ bool encodeAssembly(std::unique_ptr<CAssemblerCommand> content, SymbolData& symD
 		validationPasses++;
 	} while (Revalidate == true);
 
+	Allocations::validateOverlap();
+
 	Logger::printQueue();
 	if (Logger::hasError() == true)
 	{

--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -2,6 +2,7 @@
 #include "Assembler.h"
 #include "Core/Common.h"
 #include "Commands/CAssemblerCommand.h"
+#include "Core/Allocations.h"
 #include "Core/FileManager.h"
 #include "Parser/Parser.h"
 #include "Archs/ARM/Arm.h"
@@ -126,6 +127,7 @@ bool runArmips(ArmipsArguments& settings)
 
 	Tokenizer::clearEquValues();
 	Logger::clear();
+	Allocations::clear();
 	Global.Table.clear();
 	Global.symbolTable.clear();
 

--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -115,6 +115,13 @@ bool encodeAssembly(std::unique_ptr<CAssemblerCommand> content, SymbolData& symD
 	return true;
 }
 
+static void printStats(const AllocationStats &stats) {
+	Logger::printLine(L"Total: %lld / %lld", stats.totalUsage, stats.totalSize);
+	Logger::printLine(L"Largest: 0x%08llX, %lld / %lld", stats.largestPosition, stats.largestUsage, stats.largestSize);
+	int64_t startFreePosition = stats.largestFreePosition + stats.largestFreeUsage;
+	Logger::printLine(L"Most free: 0x%08llX, %lld / %lld (free at 0x%08llX)", stats.largestFreePosition, stats.largestFreeUsage, stats.largestFreeSize, startFreePosition);
+}
+
 bool runArmips(ArmipsArguments& settings)
 {
 	// initialize and reset global data
@@ -210,6 +217,9 @@ bool runArmips(ArmipsArguments& settings)
 		for (size_t i = 0; i < errors.size(); i++)
 			settings.errorsResult->push_back(errors[i]);
 	}
+
+	if (settings.showStats)
+		printStats(Allocations::collectStats());
 
 	return result;
 }

--- a/Core/Assembler.h
+++ b/Core/Assembler.h
@@ -29,6 +29,7 @@ struct ArmipsArguments
 	int symFileVersion;
 	bool errorOnWarning;
 	bool silent;
+	bool showStats;
 	StringList* errorsResult;
 	std::vector<EquationDefinition> equList;
 	std::vector<LabelDefinition> labels;
@@ -49,6 +50,7 @@ struct ArmipsArguments
 		symFileVersion = 0;
 		errorOnWarning = false;
 		silent = false;
+		showStats = false;
 		errorsResult = nullptr;
 		useAbsoluteFileNames = true;
 	}

--- a/Main/CommandLineInterface.cpp
+++ b/Main/CommandLineInterface.cpp
@@ -25,14 +25,6 @@ static void printUsage(std::wstring executableName)
 	Logger::printLine(L" <FILE>                    Main assembly code file");
 }
 
-static void printStats(const AllocationStats &stats)
-{
-	Logger::printLine(L"Total: %lld / %lld", stats.totalUsage, stats.totalSize);
-	Logger::printLine(L"Largest: 0x%08llX, %lld / %lld", stats.largestPosition, stats.largestUsage, stats.largestSize);
-	int64_t startFreePosition = stats.largestFreePosition + stats.largestFreeUsage;
-	Logger::printLine(L"Most free: 0x%08llX, %lld / %lld (free at 0x%08llX)", stats.largestFreePosition, stats.largestFreeUsage, stats.largestFreeSize, startFreePosition);
-}
-
 static bool parseArguments(const StringList& arguments, ArmipsArguments& settings)
 {
 	size_t argpos = 1;
@@ -230,9 +222,6 @@ int runFromCommandLine(const StringList& arguments, ArmipsArguments settings)
 
 		return 1;
 	}
-
-	if (settings.showStats)
-		printStats(Allocations::collectStats());
 
 	return 0;
 }

--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,14 @@ Equivalent to using `.definelabel name, replacement` in the assembly code.
 #### `-root <directory>`
 Specifies the working directory to be used during execution.
 
+#### `-stat`
+Outputs statistics for bytes used within areas after completion.  Example output:
+```
+Total: 5342 / 7934
+Largest: 0x0806E80C, 532 / 1156
+Most free: 0x0806E80C, 532 / 1156 (free at 0x0806EA20)
+```
+
 # 2. Installation
 
 ## 2.1 Download binary

--- a/Tests/Area/Size/expected.txt
+++ b/Tests/Area/Size/expected.txt
@@ -1,2 +1,2 @@
-Size.asm(13) error: Area overflowed
-Size.asm(20) error: Area overflowed
+Size.asm(13) error: Area at 00000010 overflowed by 4 bytes
+Size.asm(20) error: Area at 00000018 overflowed by 4 bytes

--- a/libarmips.vcxproj
+++ b/libarmips.vcxproj
@@ -242,6 +242,7 @@
     <ClCompile Include="Commands\CDirectiveFile.cpp" />
     <ClCompile Include="Commands\CDirectiveMessage.cpp" />
     <ClCompile Include="Commands\CommandSequence.cpp" />
+    <ClCompile Include="Core\Allocations.cpp" />
     <ClCompile Include="Core\Assembler.cpp" />
     <ClCompile Include="Core\Common.cpp" />
     <ClCompile Include="Core\ELF\ElfFile.cpp" />
@@ -298,6 +299,7 @@
     <ClInclude Include="Commands\CDirectiveFile.h" />
     <ClInclude Include="Commands\CDirectiveMessage.h" />
     <ClInclude Include="Commands\CommandSequence.h" />
+    <ClInclude Include="Core\Allocations.h" />
     <ClInclude Include="Core\Assembler.h" />
     <ClInclude Include="Core\Common.h" />
     <ClInclude Include="Core\ELF\ElfFile.h" />

--- a/libarmips.vcxproj.filters
+++ b/libarmips.vcxproj.filters
@@ -172,6 +172,9 @@
     <ClCompile Include="Core\ExpressionFunctions.cpp">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="Core\Allocations.cpp">
+      <Filter>Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Archs\Architecture.h">
@@ -317,6 +320,9 @@
       <Filter>Archs\MIPS</Filter>
     </ClInclude>
     <ClInclude Include="Core\ExpressionFunctions.h">
+      <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="Core\Allocations.h">
       <Filter>Core</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
While working on a recent patch, I ran into a few dumb errors on my part:

 * `.endaera` was reported as a bad THUMB opcode which confused me momentarily.  IMHO, much better to show the token in the error.
 * A couple times I'd overflow areas where space was tight, and had to manually count instructions or add logs to see how far over I was.  No reason the error can't just say.
 * When trying to reuse some free space, I stuffed [a function](https://github.com/unknownbrackets/tomatotrans/blob/a6c96c3f72fe06db569f5ff2f442d53e41190016/asm/dialog_item.asm#L157) into [another area](https://github.com/unknownbrackets/tomatotrans/blob/a6c96c3f72fe06db569f5ff2f442d53e41190016/asm/dialog_center.asm#L342-L343), in different files for semantics/understandability.  But I was always zero filling areas, so I had some fun realizing that was why PC jumped to outer space unexpectedly (when hitting a func after that zero fill.)

This adds or improves warnings for each of the above scenarios.

Related, this also adds `-stat` which allows you to see how you're doing on space overall, and where there's free space.

In my case, I removed a super inefficient jump table (it was mostly `default:` and pretty sure it neither saved cycles or space...), but I stuffed a few funcs in there and started to wonder just how much space I had left.  Turns out it's still over 50% free, now that I added `-stat`.

In theory, this could be used for automatic free space allocation.  Would just need to wipe area suballocations each validation pass (i.e. on `setArea()` or something maybe.)

-[Unknown]