### PR TITLE
Add pool info to stats output

### DIFF
--- a/Archs/ARM/Pool.cpp
+++ b/Archs/ARM/Pool.cpp
@@ -2,6 +2,7 @@
 #include <unordered_map>
 #include "Pool.h"
 #include "Arm.h"
+#include "Core/Allocations.h"
 #include "Core/Common.h"
 #include "Core/FileManager.h"
 
@@ -33,11 +34,14 @@ void ArmStateCommand::writeSymData(SymbolData& symData) const
 
 ArmPoolCommand::ArmPoolCommand()
 {
-
+	position = -1;
 }
 
 bool ArmPoolCommand::Validate()
 {
+	int64_t fileID = g_fileManager->getOpenFileID();
+	if (position != -1)
+		Allocations::forgetPool(fileID, position, values.size() * 4);
 	position = g_fileManager->getVirtualAddress();
 
 	size_t oldSize = values.size();
@@ -69,6 +73,7 @@ bool ArmPoolCommand::Validate()
 
 	Arm.clearPoolContent();
 	g_fileManager->advanceMemory(values.size()*4);
+	Allocations::setPool(fileID, position, values.size() * 4);
 
 	return oldSize != values.size();
 }

--- a/Archs/ARM/Pool.cpp
+++ b/Archs/ARM/Pool.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <unordered_map>
 #include "Pool.h"
 #include "Arm.h"
 #include "Core/Common.h"
@@ -42,6 +43,7 @@ bool ArmPoolCommand::Validate()
 	size_t oldSize = values.size();
 	values.clear();
 
+	std::unordered_map<int32_t, size_t> usedValues;
 	for (ArmPoolEntry& entry: Arm.getPoolContent())
 	{
 		size_t index = values.size();
@@ -50,18 +52,16 @@ bool ArmPoolCommand::Validate()
 		// we aren't in an unordinarily long validation loop
 		if (Global.validationPasses < 10)
 		{
-			for (size_t i = 0; i < values.size(); i++)
-			{
-				if (values[i] == entry.value)
-				{
-					index = i;
-					break;
-				}
-			}
+			auto it = usedValues.find(entry.value);
+			if (it != usedValues.end())
+				index = it->second;
 		}
 
 		if (index == values.size())
+		{
+			usedValues[entry.value] = index;
 			values.push_back(entry.value);
+		}
 
 		entry.command->applyFileInfo();
 		entry.command->setPoolAddress(position+index*4);

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -68,12 +68,11 @@ bool CDirectiveArea::Validate()
 	if (areaSize != oldAreaSize || contentSize != oldContentSize)
 		result = true;
 
-	std::shared_ptr<AssemblerFile> file = g_fileManager->getOpenFile();
-	static_assert(sizeof(int64_t) >= sizeof(intptr_t), "Assumes pointers are <= 64 bit");
+	int64_t fileID = g_fileManager->getOpenFileID();
 	if ((oldPosition != position || areaSize == 0) && oldAreaSize != 0)
-		Allocations::forgetArea((int64_t)(intptr_t)file.get(), oldPosition, oldAreaSize);
+		Allocations::forgetArea(fileID, oldPosition, oldAreaSize);
 	if (areaSize != 0)
-		Allocations::setArea((int64_t)(intptr_t)file.get(), position, areaSize, contentSize, fillExpression.isLoaded());
+		Allocations::setArea(fileID, position, areaSize, contentSize, fillExpression.isLoaded());
 
 	return result;
 }

--- a/Core/Allocations.cpp
+++ b/Core/Allocations.cpp
@@ -19,9 +19,8 @@ void Allocations::forgetArea(int64_t fileID, int64_t position, int64_t space)
 {
 	Key key{ fileID, position };
 	auto it = allocations.find(key);
-	if (it != allocations.end() && it->second.space == space) {
+	if (it != allocations.end() && it->second.space == space)
 		allocations.erase(it);
-	}
 }
 
 void Allocations::validateOverlap()

--- a/Core/Allocations.cpp
+++ b/Core/Allocations.cpp
@@ -3,6 +3,7 @@
 #include "Core/Common.h"
 
 std::map<Allocations::Key, Allocations::Usage> Allocations::allocations;
+std::map<Allocations::Key, int64_t> Allocations::pools;
 
 void Allocations::clear()
 {
@@ -21,6 +22,20 @@ void Allocations::forgetArea(int64_t fileID, int64_t position, int64_t space)
 	auto it = allocations.find(key);
 	if (it != allocations.end() && it->second.space == space)
 		allocations.erase(it);
+}
+
+void Allocations::setPool(int64_t fileID, int64_t position, int64_t size)
+{
+	Key key{ fileID, position };
+	pools[key] = size;
+}
+
+void Allocations::forgetPool(int64_t fileID, int64_t position, int64_t size)
+{
+	Key key{ fileID, position };
+	auto it = pools.find(key);
+	if (it != pools.end() && it->second == size)
+		pools.erase(it);
 }
 
 void Allocations::validateOverlap()
@@ -58,7 +73,13 @@ void Allocations::validateOverlap()
 AllocationStats Allocations::collectStats()
 {
 	AllocationStats stats{};
+	collectAreaStats(stats);
+	collectPoolStats(stats);
+	return stats;
+}
 
+void Allocations::collectAreaStats(AllocationStats &stats)
+{
 	// Need to work out overlaps.
 	Key lastKey{ -1, -1 };
 	int64_t lastEndPosition = -1;
@@ -113,6 +134,18 @@ AllocationStats Allocations::collectStats()
 
 	if (lastKey.position != -1)
 		applyUsage(lastKey.position, lastUsage);
+}
 
-	return stats;
+void Allocations::collectPoolStats(AllocationStats &stats)
+{
+	for (auto it : pools)
+	{
+		if (it.second > stats.largestPoolSize)
+		{
+			stats.largestPoolPosition = it.first.position;
+			stats.largestPoolSize = it.second;
+		}
+
+		stats.totalPoolSize += it.second;
+	}
 }

--- a/Core/Allocations.h
+++ b/Core/Allocations.h
@@ -14,6 +14,10 @@ struct AllocationStats
 
 	int64_t totalSize;
 	int64_t totalUsage;
+
+	int64_t largestPoolPosition;
+	int64_t largestPoolSize;
+	int64_t totalPoolSize;
 };
 
 class Allocations
@@ -22,6 +26,9 @@ public:
 	static void clear();
 	static void setArea(int64_t fileID, int64_t position, int64_t space, int64_t usage, bool usesFill);
 	static void forgetArea(int64_t fileID, int64_t position, int64_t space);
+
+	static void setPool(int64_t fileID, int64_t position, int64_t size);
+	static void forgetPool(int64_t fileID, int64_t position, int64_t size);
 
 	static void validateOverlap();
 	static AllocationStats collectStats();
@@ -43,5 +50,10 @@ private:
 		int64_t usage;
 		bool usesFill;
 	};
+
+	static void collectAreaStats(AllocationStats &stats);
+	static void collectPoolStats(AllocationStats &stats);
+
 	static std::map<Key, Usage> allocations;
+	static std::map<Key, int64_t> pools;
 };

--- a/Core/Allocations.h
+++ b/Core/Allocations.h
@@ -2,7 +2,8 @@
 
 #include <map>
 
-struct AllocationStats {
+struct AllocationStats
+{
 	int64_t largestPosition;
 	int64_t largestSize;
 	int64_t largestUsage;
@@ -15,7 +16,8 @@ struct AllocationStats {
 	int64_t totalUsage;
 };
 
-class Allocations {
+class Allocations
+{
 public:
 	static void clear();
 	static void setArea(int64_t fileID, int64_t position, int64_t space, int64_t usage, bool usesFill);
@@ -25,7 +27,8 @@ public:
 	static AllocationStats collectStats();
 
 private:
-	struct Key {
+	struct Key
+	{
 		int64_t fileID;
 		int64_t position;
 
@@ -34,7 +37,8 @@ private:
 			return std::tie(fileID, position) < std::tie(other.fileID, other.position);
 		}
 	};
-	struct Usage {
+	struct Usage
+	{
 		int64_t space;
 		int64_t usage;
 		bool usesFill;

--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -115,11 +115,18 @@ bool encodeAssembly(std::unique_ptr<CAssemblerCommand> content, SymbolData& symD
 	return true;
 }
 
-static void printStats(const AllocationStats &stats) {
-	Logger::printLine(L"Total: %lld / %lld", stats.totalUsage, stats.totalSize);
-	Logger::printLine(L"Largest: 0x%08llX, %lld / %lld", stats.largestPosition, stats.largestUsage, stats.largestSize);
+static void printStats(const AllocationStats &stats)
+{
+	Logger::printLine(L"Total areas: %lld / %lld", stats.totalUsage, stats.totalSize);
+	Logger::printLine(L"Largest area: 0x%08llX, %lld / %lld", stats.largestPosition, stats.largestUsage, stats.largestSize);
 	int64_t startFreePosition = stats.largestFreePosition + stats.largestFreeUsage;
-	Logger::printLine(L"Most free: 0x%08llX, %lld / %lld (free at 0x%08llX)", stats.largestFreePosition, stats.largestFreeUsage, stats.largestFreeSize, startFreePosition);
+	Logger::printLine(L"Most free area: 0x%08llX, %lld / %lld (free at 0x%08llX)", stats.largestFreePosition, stats.largestFreeUsage, stats.largestFreeSize, startFreePosition);
+
+	if (stats.totalPoolSize != 0)
+	{
+		Logger::printLine(L"Total pool size: %lld", stats.totalPoolSize);
+		Logger::printLine(L"Largest pool: 0x%08llX, %lld", stats.largestPoolPosition, stats.largestPoolSize);
+	}
 }
 
 bool runArmips(ArmipsArguments& settings)

--- a/Core/FileManager.cpp
+++ b/Core/FileManager.cpp
@@ -371,3 +371,11 @@ bool FileManager::advanceMemory(size_t bytes)
 	int64_t pos = activeFile->getVirtualAddress();
 	return activeFile->seekVirtual(pos+bytes);
 }
+
+int64_t FileManager::getOpenFileID() {
+	if (checkActiveFile() == false)
+		return 0;
+
+	static_assert(sizeof(int64_t) >= sizeof(intptr_t), "Assumes pointers are <= 64 bit");
+	return (int64_t)(intptr_t)activeFile.get();
+}

--- a/Core/FileManager.h
+++ b/Core/FileManager.h
@@ -81,6 +81,7 @@ public:
 	bool seekPhysical(int64_t physicalAddress);
 	bool advanceMemory(size_t bytes);
 	std::shared_ptr<AssemblerFile> getOpenFile() { return activeFile; };
+	int64_t getOpenFileID();
 	void setEndianness(Endianness endianness) { this->endianness = endianness; };
 	Endianness getEndianness() { return endianness; }
 private:

--- a/Readme.md
+++ b/Readme.md
@@ -68,9 +68,9 @@ Specifies the working directory to be used during execution.
 #### `-stat`
 Outputs statistics for bytes used within areas after completion.  Example output:
 ```
-Total: 5342 / 7934
-Largest: 0x0806E80C, 532 / 1156
-Most free: 0x0806E80C, 532 / 1156 (free at 0x0806EA20)
+Total areas: 5342 / 7934
+Largest area: 0x0806E80C, 532 / 1156
+Most free area: 0x0806E80C, 532 / 1156 (free at 0x0806EA20)
 ```
 
 # 2. Installation


### PR DESCRIPTION
This also includes a small optimization to pool value allocation.  No need to have an O(n) loop when we can have a typically O(1) lookup.  Won't make much difference in small pools.

The pool stats look like this:

```
Total pool size: 632
Largest pool: 0x08071470, 36
```

Didn't include in the README since it's ARM only (and only when you use pools, so old ARM at that), and stats already takes up enough space there.

In a lot of cases, there can be duplicate pool values (for various reasons) This can be a helpful stat to review your space usage, just like area stats.

Note: this will cause some small conflicts with #173 because it includes some cleanup that did as well.  Will rebase either one merged first.

-[Unknown]