### PR TITLE
Switch to 64-bit for MSVC in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     - os: windows
       compiler: "msvc2017"
       script:
-        - cmake CMakeLists.txt
+        - cmake -DCMAKE_GENERATOR_PLATFORM=x64 CMakeLists.txt
         - cmake  --build . --config Release
         - ctest -C Release --output-on-failure
     - os: windows


### PR DESCRIPTION
At the moment, it's building 32-bit builds.  It's not terrible to check both, but I know 32-bit builds on Windows may eventually be dropped along with XP/etc.

-[Unknown]