### PR TITLE
Fix build with Visual Studio 2019 CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 
 # Temporary dir for compiled headers.
 /ipch/
+
+# Visual Studio CMake directories.
+/.vs/
+/out/

--- a/Core/ExpressionFunctions.h
+++ b/Core/ExpressionFunctions.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 class Label;


### PR DESCRIPTION
In Visual Studio 2019, you can load a `CMakeLists.txt` file directly to generate a solution. This works (almost) like a charm for armips. This PR fixes a build problem and adds the folders generated by Visual Studio to `.gitignore`.