### PR TITLE
Disallow file directives within area/region/func

### DIFF
--- a/Archs/ARM/CArmInstruction.cpp
+++ b/Archs/ARM/CArmInstruction.cpp
@@ -58,7 +58,7 @@ void CArmInstruction::setPoolAddress(int64_t address)
 	Vars.Immediate = pos;
 }
 
-bool CArmInstruction::Validate()
+bool CArmInstruction::Validate(const ValidateState &state)
 {
 	RamPos = g_fileManager->getVirtualAddress();
 

--- a/Archs/ARM/CArmInstruction.h
+++ b/Archs/ARM/CArmInstruction.h
@@ -64,7 +64,7 @@ public:
 	CArmInstruction(const tArmOpcode& sourceOpcode, ArmOpcodeVariables& vars);
 //	~CArmInstruction();
 	bool Load(char* Name, char* Params);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void setPoolAddress(int64_t address);

--- a/Archs/ARM/CThumbInstruction.cpp
+++ b/Archs/ARM/CThumbInstruction.cpp
@@ -32,7 +32,7 @@ void CThumbInstruction::setPoolAddress(int64_t address)
 	Vars.Immediate = pos >> 2;
 }
 
-bool CThumbInstruction::Validate()
+bool CThumbInstruction::Validate(const ValidateState &state)
 {
 	RamPos = g_fileManager->getVirtualAddress();
 

--- a/Archs/ARM/CThumbInstruction.h
+++ b/Archs/ARM/CThumbInstruction.h
@@ -23,7 +23,7 @@ public:
 	CThumbInstruction(const tThumbOpcode& sourceOpcode, ThumbOpcodeVariables& vars);
 //	~CThumbInstruction();
 	bool Load(char* Name, char* Params);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	size_t GetSize() { return OpcodeSize; };

--- a/Archs/ARM/Pool.cpp
+++ b/Archs/ARM/Pool.cpp
@@ -57,7 +57,7 @@ bool ArmPoolCommand::Validate(const ValidateState &state)
 		
 		// try to filter redundant values, but only if
 		// we aren't in an unordinarily long validation loop
-		if (Global.validationPasses < 10)
+		if (state.passes < 10)
 		{
 			auto it = usedValues.find(entry.value);
 			if (it != usedValues.end())

--- a/Archs/ARM/Pool.cpp
+++ b/Archs/ARM/Pool.cpp
@@ -14,7 +14,7 @@ ArmStateCommand::ArmStateCommand(bool state)
 	armstate = state;
 }
 
-bool ArmStateCommand::Validate()
+bool ArmStateCommand::Validate(const ValidateState &state)
 {
 	RamPos = g_fileManager->getVirtualAddress();
 	return false;
@@ -40,7 +40,7 @@ ArmPoolCommand::ArmPoolCommand()
 	position = -1;
 }
 
-bool ArmPoolCommand::Validate()
+bool ArmPoolCommand::Validate(const ValidateState &state)
 {
 	int64_t fileID = g_fileManager->getOpenFileID();
 	if (position != -1)

--- a/Archs/ARM/Pool.h
+++ b/Archs/ARM/Pool.h
@@ -9,7 +9,7 @@ class ArmStateCommand: public CAssemblerCommand
 {
 public:
 	ArmStateCommand(bool state);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const { };
 	virtual void writeTempData(TempData& tempData) const { };
 	virtual void writeSymData(SymbolData& symData) const;
@@ -30,7 +30,7 @@ class ArmPoolCommand: public CAssemblerCommand
 {
 public:
 	ArmPoolCommand();
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Archs/Architecture.cpp
+++ b/Archs/Architecture.cpp
@@ -22,7 +22,7 @@ ArchitectureCommand::ArchitectureCommand(const std::wstring& tempText, const std
 	this->endianness = Arch->getEndianness();
 }
 
-bool ArchitectureCommand::Validate()
+bool ArchitectureCommand::Validate(const ValidateState &state)
 {
 	position = g_fileManager->getVirtualAddress();
 	g_fileManager->setEndianness(endianness);

--- a/Archs/Architecture.h
+++ b/Archs/Architecture.h
@@ -31,7 +31,7 @@ class ArchitectureCommand: public CAssemblerCommand
 {
 public:
 	ArchitectureCommand(const std::wstring& tempText, const std::wstring& symText);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Archs/MIPS/CMipsInstruction.cpp
+++ b/Archs/MIPS/CMipsInstruction.cpp
@@ -82,7 +82,7 @@ int CMipsInstruction::floatToHalfFloat(int i)
 	return s | (e << 10) | (f >> 13);
 }
 
-bool CMipsInstruction::Validate()
+bool CMipsInstruction::Validate(const ValidateState &state)
 {
 	bool Result = false;
 

--- a/Archs/MIPS/CMipsInstruction.h
+++ b/Archs/MIPS/CMipsInstruction.h
@@ -130,7 +130,7 @@ class CMipsInstruction: public CAssemblerCommand
 public:
 	CMipsInstruction(MipsOpcodeData& opcode, MipsImmediateData& immediate, MipsRegisterData& registers);
 	~CMipsInstruction();
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 private:

--- a/Archs/MIPS/MipsElfFile.cpp
+++ b/Archs/MIPS/MipsElfFile.cpp
@@ -294,7 +294,7 @@ DirectiveLoadMipsElf::DirectiveLoadMipsElf(const std::wstring& inputName, const 
 	g_fileManager->addFile(file);
 }
 
-bool DirectiveLoadMipsElf::Validate()
+bool DirectiveLoadMipsElf::Validate(const ValidateState &state)
 {
 	Arch->NextSection();
 	g_fileManager->openFile(file,true);

--- a/Archs/MIPS/MipsElfFile.h
+++ b/Archs/MIPS/MipsElfFile.h
@@ -43,7 +43,7 @@ class DirectiveLoadMipsElf: public CAssemblerCommand
 public:
 	DirectiveLoadMipsElf(const std::wstring& fileName);
 	DirectiveLoadMipsElf(const std::wstring& inputName, const std::wstring& outputName);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Archs/MIPS/MipsMacros.cpp
+++ b/Archs/MIPS/MipsMacros.cpp
@@ -17,11 +17,11 @@ MipsMacroCommand::MipsMacroCommand(std::unique_ptr<CAssemblerCommand> content, i
 	IgnoreLoadDelay = Mips.GetIgnoreDelay();
 }
 
-bool MipsMacroCommand::Validate()
+bool MipsMacroCommand::Validate(const ValidateState &state)
 {
 	int64_t memoryPos = g_fileManager->getVirtualAddress();
 	content->applyFileInfo();
-	bool result = content->Validate();
+	bool result = content->Validate(state);
 	int64_t newMemoryPos = g_fileManager->getVirtualAddress();
 
 	applyFileInfo();

--- a/Archs/MIPS/MipsMacros.h
+++ b/Archs/MIPS/MipsMacros.h
@@ -59,7 +59,7 @@ class MipsMacroCommand: public CAssemblerCommand
 {
 public:
 	MipsMacroCommand(std::unique_ptr<CAssemblerCommand> content, int macroFlags);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 private:

--- a/Archs/MIPS/PsxRelocator.cpp
+++ b/Archs/MIPS/PsxRelocator.cpp
@@ -561,7 +561,7 @@ DirectivePsxObjImport::DirectivePsxObjImport(const std::wstring& fileName)
 	}
 }
 
-bool DirectivePsxObjImport::Validate()
+bool DirectivePsxObjImport::Validate(const ValidateState &state)
 {
 	int memory = (int) g_fileManager->getVirtualAddress();
 	rel.relocate(memory);

--- a/Archs/MIPS/PsxRelocator.h
+++ b/Archs/MIPS/PsxRelocator.h
@@ -77,7 +77,7 @@ class DirectivePsxObjImport: public CAssemblerCommand
 public:
 	DirectivePsxObjImport(const std::wstring& fileName);
 	~DirectivePsxObjImport() { };
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const { };
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Commands/CAssemblerCommand.h
+++ b/Commands/CAssemblerCommand.h
@@ -7,6 +7,7 @@ struct ValidateState
 {
 	bool noFileChange = false;
 	const wchar_t *noFileChangeDirective = nullptr;
+	int passes = 0;
 };
 
 class CAssemblerCommand

--- a/Commands/CAssemblerCommand.h
+++ b/Commands/CAssemblerCommand.h
@@ -5,7 +5,8 @@ class SymbolData;
 
 struct ValidateState
 {
-	bool allowFileChange = true;
+	bool noFileChange = false;
+	const wchar_t *noFileChangeDirective = nullptr;
 };
 
 class CAssemblerCommand

--- a/Commands/CAssemblerCommand.h
+++ b/Commands/CAssemblerCommand.h
@@ -3,12 +3,17 @@
 class TempData;
 class SymbolData;
 
+struct ValidateState
+{
+	bool allowFileChange = true;
+};
+
 class CAssemblerCommand
 {
 public:
 	CAssemblerCommand();
 	virtual ~CAssemblerCommand() { };
-	virtual bool Validate() = 0;
+	virtual bool Validate(const ValidateState &state) = 0;
 	virtual void Encode() const = 0;
 	virtual void writeTempData(TempData& tempData) const = 0;
 	virtual void writeSymData(SymbolData& symData) const { };
@@ -25,7 +30,7 @@ private:
 class DummyCommand: public CAssemblerCommand
 {
 public:
-	virtual bool Validate() { return false; };
+	bool Validate(const ValidateState &state) override { return false; }
 	virtual void Encode() const { };
 	virtual void writeTempData(TempData& tempData) const { };
 	virtual void writeSymData(SymbolData& symData) const { };
@@ -34,7 +39,7 @@ public:
 class InvalidCommand: public CAssemblerCommand
 {
 public:
-	virtual bool Validate() { return false; };
+	bool Validate(const ValidateState &state) override { return false; }
 	virtual void Encode() const { };
 	virtual void writeTempData(TempData& tempData) const { };
 	virtual void writeSymData(SymbolData& symData) const { };

--- a/Commands/CAssemblerLabel.cpp
+++ b/Commands/CAssemblerLabel.cpp
@@ -40,7 +40,7 @@ CAssemblerLabel::CAssemblerLabel(const std::wstring& name, const std::wstring& o
 	labelValue = value;
 }
 
-bool CAssemblerLabel::Validate()
+bool CAssemblerLabel::Validate(const ValidateState &state)
 {
 	bool result = false;
 	if (defined == false)
@@ -120,15 +120,15 @@ CDirectiveFunction::CDirectiveFunction(const std::wstring& name, const std::wstr
 	this->start = this->end = 0;
 }
 
-bool CDirectiveFunction::Validate()
+bool CDirectiveFunction::Validate(const ValidateState &state)
 {
 	start = g_fileManager->getVirtualAddress();
 
 	label->applyFileInfo();
-	bool result = label->Validate();
+	bool result = label->Validate(state);
 
 	content->applyFileInfo();
-	if (content->Validate())
+	if (content->Validate(state))
 		result = true;
 
 	end = g_fileManager->getVirtualAddress();

--- a/Commands/CAssemblerLabel.cpp
+++ b/Commands/CAssemblerLabel.cpp
@@ -127,8 +127,11 @@ bool CDirectiveFunction::Validate(const ValidateState &state)
 	label->applyFileInfo();
 	bool result = label->Validate(state);
 
+	ValidateState contentValidation = state;
+	contentValidation.noFileChange = true;
+	contentValidation.noFileChangeDirective = L"function";
 	content->applyFileInfo();
-	if (content->Validate(state))
+	if (content->Validate(contentValidation))
 		result = true;
 
 	end = g_fileManager->getVirtualAddress();

--- a/Commands/CAssemblerLabel.h
+++ b/Commands/CAssemblerLabel.h
@@ -10,7 +10,7 @@ class CAssemblerLabel: public CAssemblerCommand
 public:
 	CAssemblerLabel(const std::wstring& name, const std::wstring& originalName);
 	CAssemblerLabel(const std::wstring& name, const std::wstring& originalName, Expression& value);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;
@@ -24,7 +24,7 @@ class CDirectiveFunction: public CAssemblerCommand
 {
 public:
 	CDirectiveFunction(const std::wstring& name, const std::wstring& originalName);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -32,7 +32,7 @@ void CDirectiveArea::setPositionExpression(Expression& exp)
 	positionExpression = exp;
 }
 
-bool CDirectiveArea::Validate()
+bool CDirectiveArea::Validate(const ValidateState &state)
 {
 	int64_t oldAreaSize = areaSize;
 	int64_t oldContentSize = contentSize;
@@ -76,7 +76,7 @@ bool CDirectiveArea::Validate()
 	if (content)
 	{
 		content->applyFileInfo();
-		result = content->Validate();
+		result = content->Validate(state);
 	}
 	contentSize = g_fileManager->getVirtualAddress()-position;
 
@@ -199,7 +199,7 @@ void CDirectiveAutoRegion::setRangeExpressions(Expression& minExp, Expression& m
 	maxRangeExpression = maxExp;
 }
 
-bool CDirectiveAutoRegion::Validate()
+bool CDirectiveAutoRegion::Validate(const ValidateState &state)
 {
 	resetPosition = g_fileManager->getVirtualAddress();
 
@@ -209,7 +209,7 @@ bool CDirectiveAutoRegion::Validate()
 		// Just calculate contentSize.
 		position = g_fileManager->getVirtualAddress();
 		content->applyFileInfo();
-		content->Validate();
+		content->Validate(state);
 		contentSize = g_fileManager->getVirtualAddress() - position;
 
 		g_fileManager->seekVirtual(resetPosition);
@@ -249,7 +249,7 @@ bool CDirectiveAutoRegion::Validate()
 	g_fileManager->seekVirtual(position);
 
 	content->applyFileInfo();
-	bool result = content->Validate();
+	bool result = content->Validate(state);
 	contentSize = g_fileManager->getVirtualAddress() - position;
 
 	// restore info of this command

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -75,8 +75,11 @@ bool CDirectiveArea::Validate(const ValidateState &state)
 	bool result = false;
 	if (content)
 	{
+		ValidateState contentValidation = state;
+		contentValidation.noFileChange = true;
+		contentValidation.noFileChangeDirective = L"area";
 		content->applyFileInfo();
-		result = content->Validate(state);
+		result = content->Validate(contentValidation);
 	}
 	contentSize = g_fileManager->getVirtualAddress()-position;
 
@@ -203,13 +206,17 @@ bool CDirectiveAutoRegion::Validate(const ValidateState &state)
 {
 	resetPosition = g_fileManager->getVirtualAddress();
 
+	ValidateState contentValidation = state;
+	contentValidation.noFileChange = true;
+	contentValidation.noFileChangeDirective = L"region";
+
 	// We need at least one full pass run before we can get an address.
 	if (Global.validationPasses < 1)
 	{
 		// Just calculate contentSize.
 		position = g_fileManager->getVirtualAddress();
 		content->applyFileInfo();
-		content->Validate(state);
+		content->Validate(contentValidation);
 		contentSize = g_fileManager->getVirtualAddress() - position;
 
 		g_fileManager->seekVirtual(resetPosition);
@@ -249,7 +256,7 @@ bool CDirectiveAutoRegion::Validate(const ValidateState &state)
 	g_fileManager->seekVirtual(position);
 
 	content->applyFileInfo();
-	bool result = content->Validate(state);
+	bool result = content->Validate(contentValidation);
 	contentSize = g_fileManager->getVirtualAddress() - position;
 
 	// restore info of this command

--- a/Commands/CDirectiveArea.cpp
+++ b/Commands/CDirectiveArea.cpp
@@ -211,7 +211,7 @@ bool CDirectiveAutoRegion::Validate(const ValidateState &state)
 	contentValidation.noFileChangeDirective = L"region";
 
 	// We need at least one full pass run before we can get an address.
-	if (Global.validationPasses < 1)
+	if (state.passes < 1)
 	{
 		// Just calculate contentSize.
 		position = g_fileManager->getVirtualAddress();

--- a/Commands/CDirectiveArea.h
+++ b/Commands/CDirectiveArea.h
@@ -7,7 +7,7 @@ class CDirectiveArea: public CAssemblerCommand
 {
 public:
 	CDirectiveArea(bool shared, Expression& size);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;
@@ -30,7 +30,7 @@ class CDirectiveAutoRegion : public CAssemblerCommand
 {
 public:
 	CDirectiveAutoRegion();
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Commands/CDirectiveConditional.cpp
+++ b/Commands/CDirectiveConditional.cpp
@@ -64,7 +64,7 @@ bool CDirectiveConditional::evaluate()
 	return false;
 }
 
-bool CDirectiveConditional::Validate()
+bool CDirectiveConditional::Validate(const ValidateState &state)
 {
 	bool result = evaluate();
 	bool returnValue = result != previousResult;
@@ -73,12 +73,12 @@ bool CDirectiveConditional::Validate()
 	if (result)
 	{
 		ifBlock->applyFileInfo();
-		if (ifBlock->Validate())
+		if (ifBlock->Validate(state))
 			returnValue = true;
 	} else if (elseBlock != nullptr)
 	{
 		elseBlock->applyFileInfo();
-		if (elseBlock->Validate())
+		if (elseBlock->Validate(state))
 			returnValue = true;
 	}
 

--- a/Commands/CDirectiveConditional.h
+++ b/Commands/CDirectiveConditional.h
@@ -19,7 +19,7 @@ public:
 	CDirectiveConditional(ConditionType type);
 	CDirectiveConditional(ConditionType type, const std::wstring& name);
 	CDirectiveConditional(ConditionType type, const Expression& exp);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Commands/CDirectiveData.cpp
+++ b/Commands/CDirectiveData.cpp
@@ -28,7 +28,7 @@ TableCommand::TableCommand(const std::wstring& fileName, TextFile::Encoding enco
 	}
 }
 
-bool TableCommand::Validate()
+bool TableCommand::Validate(const ValidateState &state)
 {
 	Global.Table = table;
 	return false;
@@ -308,7 +308,7 @@ void CDirectiveData::encodeNormal()
 	}
 }
 
-bool CDirectiveData::Validate()
+bool CDirectiveData::Validate(const ValidateState &state)
 {
 	position = g_fileManager->getVirtualAddress();
 

--- a/Commands/CDirectiveData.h
+++ b/Commands/CDirectiveData.h
@@ -10,7 +10,7 @@ class TableCommand: public CAssemblerCommand
 {
 public:
 	TableCommand(const std::wstring& fileName, TextFile::Encoding encoding);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const { };
 	virtual void writeTempData(TempData& tempData) const { };
 	virtual void writeSymData(SymbolData& symData) const { };
@@ -29,7 +29,7 @@ public:
 	void setAscii(std::vector<Expression>& entries, bool terminate);
 	void setSjis(std::vector<Expression>& entries, bool terminate);
 	void setCustom(std::vector<Expression>& entries, bool terminate);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Commands/CDirectiveFile.cpp
+++ b/Commands/CDirectiveFile.cpp
@@ -60,7 +60,7 @@ void CDirectiveFile::initClose()
 	updateSection(++Global.Section);
 }
 
-bool CDirectiveFile::Validate()
+bool CDirectiveFile::Validate(const ValidateState &state)
 {
 	virtualAddress = g_fileManager->getVirtualAddress();
 	Arch->NextSection();
@@ -170,7 +170,7 @@ void CDirectivePosition::exec() const
 	}
 }
 
-bool CDirectivePosition::Validate()
+bool CDirectivePosition::Validate(const ValidateState &state)
 {
 	virtualAddress = g_fileManager->getVirtualAddress();
 
@@ -221,7 +221,7 @@ CDirectiveIncbin::CDirectiveIncbin(const std::wstring& fileName)
 	this->fileSize = ::fileSize(this->fileName);
 }
 
-bool CDirectiveIncbin::Validate()
+bool CDirectiveIncbin::Validate(const ValidateState &state)
 {
 	virtualAddress = g_fileManager->getVirtualAddress();
 
@@ -313,7 +313,7 @@ CDirectiveAlignFill::CDirectiveAlignFill(Expression& value, Expression& fillValu
 	fillExpression = fillValue;
 }
 
-bool CDirectiveAlignFill::Validate()
+bool CDirectiveAlignFill::Validate(const ValidateState &state)
 {
 	virtualAddress = g_fileManager->getVirtualAddress();
 
@@ -417,7 +417,7 @@ void CDirectiveAlignFill::writeSymData(SymbolData& symData) const
 CDirectiveSkip::CDirectiveSkip(Expression& expression)
 	: expression(expression) {}
 
-bool CDirectiveSkip::Validate()
+bool CDirectiveSkip::Validate(const ValidateState &state)
 {
 	virtualAddress = g_fileManager->getVirtualAddress();
 
@@ -468,7 +468,7 @@ void CDirectiveHeaderSize::exec() const
 	file->seekPhysical(physicalAddress);
 }
 
-bool CDirectiveHeaderSize::Validate()
+bool CDirectiveHeaderSize::Validate(const ValidateState &state)
 {
 	virtualAddress = g_fileManager->getVirtualAddress();
 
@@ -516,10 +516,10 @@ DirectiveObjImport::DirectiveObjImport(const std::wstring& inputName, const std:
 	}
 }
 
-bool DirectiveObjImport::Validate()
+bool DirectiveObjImport::Validate(const ValidateState &state)
 {
 	bool result = false;
-	if (ctor != nullptr && ctor->Validate())
+	if (ctor != nullptr && ctor->Validate(state))
 		result = true;
 
 	int64_t memory = g_fileManager->getVirtualAddress();

--- a/Commands/CDirectiveFile.cpp
+++ b/Commands/CDirectiveFile.cpp
@@ -62,6 +62,15 @@ void CDirectiveFile::initClose()
 
 bool CDirectiveFile::Validate(const ValidateState &state)
 {
+	if (state.noFileChange)
+	{
+		if (type == Type::Close)
+			Logger::queueError(Logger::Error, L"Cannot close file within %S", state.noFileChangeDirective);
+		else
+			Logger::queueError(Logger::Error, L"Cannot open new file within %S", state.noFileChangeDirective);
+		return false;
+	}
+
 	virtualAddress = g_fileManager->getVirtualAddress();
 	Arch->NextSection();
 

--- a/Commands/CDirectiveFile.h
+++ b/Commands/CDirectiveFile.h
@@ -18,7 +18,7 @@ public:
 	void initCopy(const std::wstring& inputName, const std::wstring& outputName, int64_t memory);
 	void initClose();
 
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;
@@ -34,7 +34,7 @@ class CDirectivePosition: public CAssemblerCommand
 public:
 	enum Type { Physical, Virtual };
 	CDirectivePosition(Expression value, Type type);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const { };
@@ -53,7 +53,7 @@ public:
 	void setStart(Expression& exp) { startExpression = exp; };
 	void setSize(Expression& exp) { sizeExpression = exp; };
 
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;
@@ -76,7 +76,7 @@ public:
 	CDirectiveAlignFill(int64_t value, Mode mode);
 	CDirectiveAlignFill(Expression& value, Mode mode);
 	CDirectiveAlignFill(Expression& value, Expression& fillValue, Mode mode);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;
@@ -94,7 +94,7 @@ class CDirectiveSkip: public CAssemblerCommand
 {
 public:
 	CDirectiveSkip(Expression& value);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const { };
@@ -108,7 +108,7 @@ class CDirectiveHeaderSize: public CAssemblerCommand
 {
 public:
 	CDirectiveHeaderSize(Expression expression);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const { };
@@ -125,7 +125,7 @@ public:
 	DirectiveObjImport(const std::wstring& inputName);
 	DirectiveObjImport(const std::wstring& inputName, const std::wstring& ctorName);
 	~DirectiveObjImport() { };
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Commands/CDirectiveMessage.cpp
+++ b/Commands/CDirectiveMessage.cpp
@@ -10,7 +10,7 @@ CDirectiveMessage::CDirectiveMessage(Type type, Expression exp)
 	this->exp = exp;
 }
 
-bool CDirectiveMessage::Validate()
+bool CDirectiveMessage::Validate(const ValidateState &state)
 {
 	std::wstring text;
 	if (exp.evaluateString(text,true) == false)

--- a/Commands/CDirectiveMessage.h
+++ b/Commands/CDirectiveMessage.h
@@ -9,7 +9,7 @@ class CDirectiveMessage: public CAssemblerCommand
 public:
 	enum class Type { Warning, Error, Notice };
 	CDirectiveMessage(Type type, Expression exp);
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const {};
 	virtual void writeTempData(TempData& tempData) const { };
 private:
@@ -21,7 +21,7 @@ class CDirectiveSym: public CAssemblerCommand
 {
 public:
 	CDirectiveSym(bool enable) {enabled = enable; };
-	virtual bool Validate() { return false; };
+	bool Validate(const ValidateState &state) override { return false; }
 	virtual void Encode() const { };
 	virtual void writeTempData(TempData& tempData) const { };
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Commands/CommandSequence.cpp
+++ b/Commands/CommandSequence.cpp
@@ -6,14 +6,14 @@ CommandSequence::CommandSequence()
 
 }
 
-bool CommandSequence::Validate()
+bool CommandSequence::Validate(const ValidateState &state)
 {
 	bool result = false;
 	
 	for (const std::unique_ptr<CAssemblerCommand>& cmd: commands)
 	{
 		cmd->applyFileInfo();
-		if (cmd->Validate())
+		if (cmd->Validate(state))
 			result = true;
 	}
 

--- a/Commands/CommandSequence.h
+++ b/Commands/CommandSequence.h
@@ -11,7 +11,7 @@ class CommandSequence: public CAssemblerCommand
 {
 public:
 	CommandSequence();
-	virtual bool Validate();
+	bool Validate(const ValidateState &state) override;
 	virtual void Encode() const;
 	virtual void writeTempData(TempData& tempData) const;
 	virtual void writeSymData(SymbolData& symData) const;

--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -50,7 +50,7 @@ bool encodeAssembly(std::unique_ptr<CAssemblerCommand> content, SymbolData& symD
 		if (Global.memoryMode)
 			g_fileManager->openFile(Global.memoryFile,true);
 
-		Revalidate = content->Validate();
+		Revalidate = content->Validate(ValidateState{});
 
 		Arm.Revalidate();
 		Mips.Revalidate();

--- a/Core/Common.h
+++ b/Core/Common.h
@@ -24,7 +24,6 @@ typedef struct {
 	int Section;
 	bool nocash;
 	bool relativeInclude;
-	int validationPasses;
 	bool memoryMode;
 	std::shared_ptr<AssemblerFile> memoryFile;
 	bool multiThreading;

--- a/Tests/Area/CloseFile/CloseFile.asm
+++ b/Tests/Area/CloseFile/CloseFile.asm
@@ -1,0 +1,17 @@
+.gba
+.create "out.bin",0
+
+.area 0x8
+.fill 0x8
+.close
+.endarea
+
+.macro myopen,offset
+	.open "out2.bin",offset
+.endmacro
+
+.area 0x8
+myopen 4
+.endarea
+
+.close

--- a/Tests/Area/CloseFile/expected.txt
+++ b/Tests/Area/CloseFile/expected.txt
@@ -1,0 +1,2 @@
+﻿CloseFile.asm(6) error: Cannot close file within area
+CloseFile.asm(14) error: Cannot open new file within area


### PR DESCRIPTION
Fixes #180.  Now an error is shown for any open or close directive within area, region, or func.

Rather than add global state to `Global`, I've added a state parameter to each `Validate()` method.  This makes it more straight forward to handle nested structures, i.e.:

```
.area 123
.func Foo
.close ; Cannot close inside func
.endfunc

.close ; Cannot close inside area
.endarea
```

-[Unknown]