### PR TITLE
Remove unnecessary Token constructors

### DIFF
--- a/Parser/Tokenizer.h
+++ b/Parser/Tokenizer.h
@@ -60,54 +60,6 @@ struct Token
 	{
 	}
 
-	Token(Token &&src)
-	{
-		// Move strings.
-		originalText = std::move(src.originalText);
-		stringValue = std::move(src.stringValue);
-
-		// Just copy the rest.
-		type = src.type;
-		line = src.line;
-		column = src.column;
-		floatValue = src.floatValue;
-		checked = src.checked;
-	}
-
-	Token(const Token &src)
-	{
-		// Copy strings.
-		setOriginalText(src.originalText);
-		setStringValue(src.stringValue);
-
-		// And copy the rest.
-		type = src.type;
-		line = src.line;
-		column = src.column;
-		floatValue = src.floatValue;
-		checked = src.checked;
-	}
-
-	~Token()
-	{
-	}
-
-	Token& operator=(const Token& src)
-	{
-		// Copy strings.
-		setOriginalText(src.originalText);
-		setStringValue(src.stringValue);
-
-		// And copy the rest.
-		type = src.type;
-		line = src.line;
-		column = src.column;
-		floatValue = src.floatValue;
-		checked = src.checked;
-
-		return *this;
-	}
-
 	void setOriginalText(const std::wstring& t)
 	{
 		setOriginalText(t, 0, t.length());


### PR DESCRIPTION
These do nothing useful compared to trivial ones now.  The move one may be causing a double free.

-[Unknown]