### PR TITLE
Fix crash when using areas with multithreading

### DIFF
--- a/Commands/CDirectiveArea.h
+++ b/Commands/CDirectiveArea.h
@@ -22,6 +22,7 @@ private:
 	int64_t contentSize;
 	Expression fillExpression;
 	int8_t fillValue;
+	int64_t fileID = 0;
 	Expression positionExpression;
 	std::unique_ptr<CAssemblerCommand> content;
 };
@@ -42,6 +43,7 @@ private:
 	int64_t resetPosition;
 	int64_t position;
 	int64_t contentSize;
+	int64_t fileID = 0;
 	Expression minRangeExpression;
 	Expression maxRangeExpression;
 	std::unique_ptr<CAssemblerCommand> content;


### PR DESCRIPTION
getOpenFileID accesses and writes to the global state, which is modified
concurrently by the encode thread. This can lead to heap corruption.