### PR TITLE
Fix macro argument error with dollar-prefixed registers

### DIFF
--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -535,15 +535,17 @@ std::unique_ptr<CAssemblerCommand> Parser::parseMacroCall()
 		}
 
 		TokenizerPosition startPos = getTokenizer()->getPosition();
-		Expression exp = parseExpression();
-		if (!exp.isLoaded())
-		{
-			printError(start,L"Invalid macro argument expression");
-			return nullptr;
-		}
+
+		while (peekToken().type != TokenType::Comma && peekToken().type != TokenType::Separator)
+			nextToken();
 
 		TokenizerPosition endPos = getTokenizer()->getPosition();
 		std::vector<Token> tokens = getTokenizer()->getTokens(startPos,endPos);
+		if (tokens.size() == 0)
+		{
+			printError(start,L"Empty macro argument");
+			return nullptr;
+		}
 
 		// remember any single identifier parameters for the label replacement
 		if (tokens.size() == 1 && tokens[0].type == TokenType::Identifier)
@@ -559,7 +561,8 @@ std::unique_ptr<CAssemblerCommand> Parser::parseMacroCall()
 		while (peekToken().type == TokenType::Comma)
 		{
 			eatToken();
-			parseExpression();
+			while (peekToken().type != TokenType::Comma && peekToken().type != TokenType::Separator)
+				nextToken();
 			count++;
 		}
 


### PR DESCRIPTION
Fixes an issue I encountered in trying to use dollar-prefixed registers as macro arguments.
For example, before the fix the following would error with "Invalid macro argument expression":
```
.rsp
.macro vclr, dst
    vxor dst, dst, dst
.endmacro

.create "test.bin", 0x1000

    vclr $v0

.close
```
I'm unsure if this fix is totally correct, or if it may break something else, however all existing tests pass. I will be glad to receive any feedback.
