### PR TITLE
Avoid some type conversion warnings

### DIFF
--- a/Core/ExpressionFunctions.cpp
+++ b/Core/ExpressionFunctions.cpp
@@ -564,7 +564,7 @@ ExpressionValue expFuncReadAscii(const Identifier &funcName, const std::vector<E
 			return ExpressionValue();
 		}
 
-		for (size_t i = 0; i < file.gcount(); i++)
+		for (std::streamsize i = 0; i < file.gcount(); i++)
 		{
 			if (buffer[i] == 0x00)
 			{

--- a/Core/Misc.cpp
+++ b/Core/Misc.cpp
@@ -145,7 +145,7 @@ void TempData::start()
 		file.writeFormat("; %d %S\n\n",equCount,equCount == 1 ? "equation" : "equations");
 		for (size_t i = 0; i < fileCount; i++)
 		{
-			file.writeFormat("; %S\n",Global.fileList.string(i));
+			file.writeFormat("; %S\n",Global.fileList.string(int(i)));
 		}
 		file.writeLine("");
 	}

--- a/Core/SymbolTable.cpp
+++ b/Core/SymbolTable.cpp
@@ -221,5 +221,5 @@ int SymbolTable::findSection(int64_t address)
 		}
 	}
 
-	return smallestBefore;
+	return int(smallestBefore);
 }

--- a/Util/FileClasses.cpp
+++ b/Util/FileClasses.cpp
@@ -722,7 +722,7 @@ bool TextFile::open(Mode mode, Encoding defaultEncoding)
 
 	if (mode == Read)
 	{
-		size_ = fs::file_size(fileName);
+		size_ = long(fs::file_size(fileName));
 
 		stream.read(reinterpret_cast<char *>(numBuffer), 3);
 		switch (numBuffer[0] | (numBuffer[1] << 8))


### PR DESCRIPTION
This avoids some type conversion warnings seen in MSVC by simply downcasting in most cases.  Practically, more than 2GB text files or millions of files aren't going to happen.

Just trying for warning-clean.

-[Unknown]