### PR TITLE
Fix GitHub actions MSVC build: set to windows-2022 and update generator to VS2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           - { name: "Ubuntu clang", os: "ubuntu-latest", generator: "Unix Makefiles", cc: "clang", cxx: "clang++" }
           - { name: "macOS clang", os: "macos-latest", generator: "Unix Makefiles", cc: "clang", cxx: "clang++" }
           - { name: "Windows clang", os: "windows-latest", generator: "Unix Makefiles", cc: "clang", cxx: "clang++" }
-          - { name: "Windows MSVC", os: "windows-latest", generator: "Visual Studio 16 2019"}
+          - { name: "Windows MSVC", os: "windows-2022", generator: "Visual Studio 17 2022"}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Currently the Windows environment for MSVC in `build.yml` is set to `windows-latest`. As of now, this resolves to `windows-2022`, which only has Visual Studio 2022 installed, so CMake is unable to find the Visual Studio 2019 generator.

This updates the generator to VS2022 and fixes the environment for MSVC to `windows-2022`, which should prevent things from breaking again when the next version of Visual Studio rolls around.