### PR TITLE
Add late check for errors before exiting (fixes #99)

### DIFF
--- a/Core/Assembler.cpp
+++ b/Core/Assembler.cpp
@@ -111,6 +111,11 @@ bool encodeAssembly(std::unique_ptr<CAssemblerCommand> content, SymbolData& symD
 		g_fileManager->closeFile();
 	}
 
+	if (Logger::hasError())
+	{
+		return false;
+	}
+
 	return true;
 }
 
@@ -230,6 +235,11 @@ bool runArmips(ArmipsArguments& settings)
 
 	if (settings.showStats)
 		printStats(Allocations::collectStats());
+
+	if (Logger::hasError())
+	{
+		return false;
+	}
 
 	return result;
 }


### PR DESCRIPTION
This adds `Logger::hasError()` checks right before exiting so that errors during the encoding step properly set the exit code to 1. Adding it here also catches the "file not closed" warning when `erroronwarning` is active.