### PR TITLE
Build fix for Xcode 12.2 / macos 10.13

### DIFF
--- a/Core/Expression.h
+++ b/Core/Expression.h
@@ -160,7 +160,7 @@ private:
 	const T &valueAs() const
 	{
 		assert(std::holds_alternative<T>(value));
-		return std::get<T>(value);
+		return *std::get_if<T>(&value);
 	}
 
 	std::string formatFunctionCall();

--- a/Parser/Tokenizer.h
+++ b/Parser/Tokenizer.h
@@ -75,25 +75,25 @@ struct Token
 	const Identifier &identifierValue() const
 	{
 		assert(std::holds_alternative<Identifier>(value));
-		return std::get<Identifier>(value);
+		return *std::get_if<Identifier>(&value);
 	}
 
 	const StringLiteral &stringValue() const
 	{
 		assert(std::holds_alternative<StringLiteral>(value));
-		return std::get<StringLiteral>(value);
+		return *std::get_if<StringLiteral>(&value);
 	}
 
 	int64_t intValue() const
 	{
 		assert(std::holds_alternative<int64_t>(value));
-		return std::get<int64_t>(value);
+		return *std::get_if<int64_t>(&value);
 	}
 
 	double floatValue() const
 	{
 		assert(std::holds_alternative<double>(value));
-		return std::get<double>(value);
+		return *std::get_if<double>(&value);
 	}
 
 	size_t line = 0;


### PR DESCRIPTION
std::variant::get is not available on older Xcode versions for older macOS versions:

https://stackoverflow.com/questions/52521388/stdvariantget-does-not-compile-with-apple-llvm-10-0