### PR TITLE
Accommodate for word size differences between different architectures.

### DIFF
--- a/Archs/ARM/Arm.h
+++ b/Archs/ARM/Arm.h
@@ -46,6 +46,7 @@ public:
 	virtual void Revalidate();
 	virtual std::unique_ptr<IElfRelocator> getElfRelocator();
 	virtual Endianness getEndianness() { return version == AARCH_BIG ? Endianness::Big : Endianness::Little; };
+	virtual int getWordSize() { return 4; };
 	void SetThumbMode(bool b) { thumb = b; };
 	bool GetThumbMode() { return thumb; };
 	void setVersion(ArmArchType type) { version = type; }

--- a/Archs/Architecture.h
+++ b/Archs/Architecture.h
@@ -25,6 +25,7 @@ public:
 	virtual void Revalidate() = 0;
 	virtual std::unique_ptr<IElfRelocator> getElfRelocator() = 0;
 	virtual Endianness getEndianness() = 0;
+	virtual int getWordSize() = 0;
 private:
 	static Architecture *currentArchitecture;
 };
@@ -53,6 +54,7 @@ public:
 	void Revalidate() override;
 	std::unique_ptr<IElfRelocator> getElfRelocator() override;
 	Endianness getEndianness() override { return Endianness::Little; }
+	int getWordSize() override { return 4; };
 };
 
 extern CInvalidArchitecture InvalidArchitecture;

--- a/Archs/MIPS/Mips.h
+++ b/Archs/MIPS/Mips.h
@@ -21,6 +21,7 @@ public:
 	{
 		return Version == MARCH_N64 || Version == MARCH_RSP ? Endianness::Big : Endianness::Little;
 	};
+	virtual int getWordSize() { return 4; };
 	void SetLoadDelay(bool Delay, int Register);
 	bool GetLoadDelay() { return LoadDelay; };
 	int GetLoadDelayRegister() { return LoadDelayRegister; };

--- a/Archs/SuperH/SuperH.h
+++ b/Archs/SuperH/SuperH.h
@@ -18,6 +18,7 @@ public:
 	virtual void Revalidate();
 	virtual std::unique_ptr<IElfRelocator> getElfRelocator();
 	virtual Endianness getEndianness() { return version == SHARCH_LITTLE ? Endianness::Little : Endianness::Big; };
+	virtual int getWordSize() { return 2; };
 	void setVersion(ShArchType type) { version = type; }
 	ShArchType getVersion() { return version; }
 

--- a/Parser/DirectivesParser.cpp
+++ b/Parser/DirectivesParser.cpp
@@ -375,6 +375,15 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveData(Parser& parser, int flags)
 	case DIRECTIVE_DATA_64:
 		data->setNormal(list,8);
 		break;
+	case DIRECTIVE_DATA_HWORD:
+		data->setNormal(list,Architecture::current().getWordSize()/2);
+		break;
+	case DIRECTIVE_DATA_WORD:
+		data->setNormal(list,Architecture::current().getWordSize());
+		break;
+	case DIRECTIVE_DATA_DWORD:
+		data->setNormal(list,Architecture::current().getWordSize()*2);
+		break;
 	case DIRECTIVE_DATA_ASCII:
 		data->setAscii(list,terminate);
 		break;
@@ -754,29 +763,35 @@ const DirectiveMap directives = {
 	{ ".loadtable",       { &parseDirectiveTable,           0 } },
 	{ ".table",           { &parseDirectiveTable,           0 } },
 	{ ".byte",            { &parseDirectiveData,            DIRECTIVE_DATA_8 } },
-	{ ".halfword",        { &parseDirectiveData,            DIRECTIVE_DATA_16 } },
-	{ ".word",            { &parseDirectiveData,            DIRECTIVE_DATA_32 } },
-	{ ".doubleword",      { &parseDirectiveData,            DIRECTIVE_DATA_64 } },
+	{ ".halfword",        { &parseDirectiveData,            DIRECTIVE_DATA_HWORD } },
+	{ ".hword",           { &parseDirectiveData,            DIRECTIVE_DATA_HWORD } },
+	{ ".word",            { &parseDirectiveData,            DIRECTIVE_DATA_WORD } },
+	{ ".doubleword",      { &parseDirectiveData,            DIRECTIVE_DATA_DWORD } },
+	{ ".dword",           { &parseDirectiveData,            DIRECTIVE_DATA_DWORD } },
 	{ ".db",              { &parseDirectiveData,            DIRECTIVE_DATA_8 } },
-	{ ".dh",              { &parseDirectiveData,            DIRECTIVE_DATA_16|DIRECTIVE_NOCASHOFF } },
-	{ ".dw",              { &parseDirectiveData,            DIRECTIVE_DATA_32|DIRECTIVE_NOCASHOFF } },
-	{ ".dd",              { &parseDirectiveData,            DIRECTIVE_DATA_64|DIRECTIVE_NOCASHOFF } },
+	{ ".dh",              { &parseDirectiveData,            DIRECTIVE_DATA_HWORD|DIRECTIVE_NOCASHOFF } },
+	{ ".dw",              { &parseDirectiveData,            DIRECTIVE_DATA_WORD|DIRECTIVE_NOCASHOFF } },
+	{ ".dd",              { &parseDirectiveData,            DIRECTIVE_DATA_DWORD|DIRECTIVE_NOCASHOFF } },
 	{ ".dw",              { &parseDirectiveData,            DIRECTIVE_DATA_16|DIRECTIVE_NOCASHON } },
 	{ ".dd",              { &parseDirectiveData,            DIRECTIVE_DATA_32|DIRECTIVE_NOCASHON } },
 	{ ".dcb",             { &parseDirectiveData,            DIRECTIVE_DATA_8 } },
-	{ ".dcw",             { &parseDirectiveData,            DIRECTIVE_DATA_16 } },
-	{ ".dcd",             { &parseDirectiveData,            DIRECTIVE_DATA_32 } },
-	{ ".dcq",             { &parseDirectiveData,            DIRECTIVE_DATA_64 } },
+	{ ".dcw",             { &parseDirectiveData,            DIRECTIVE_DATA_HWORD } },
+	{ ".dcd",             { &parseDirectiveData,            DIRECTIVE_DATA_WORD } },
+	{ ".dcq",             { &parseDirectiveData,            DIRECTIVE_DATA_DWORD } },
 	{ "db",               { &parseDirectiveData,            DIRECTIVE_DATA_8 } },
-	{ "dh",               { &parseDirectiveData,            DIRECTIVE_DATA_16|DIRECTIVE_NOCASHOFF } },
-	{ "dw",               { &parseDirectiveData,            DIRECTIVE_DATA_32|DIRECTIVE_NOCASHOFF } },
-	{ "dd",               { &parseDirectiveData,            DIRECTIVE_DATA_64|DIRECTIVE_NOCASHOFF } },
+	{ "dh",               { &parseDirectiveData,            DIRECTIVE_DATA_HWORD|DIRECTIVE_NOCASHOFF } },
+	{ "dw",               { &parseDirectiveData,            DIRECTIVE_DATA_WORD|DIRECTIVE_NOCASHOFF } },
+	{ "dd",               { &parseDirectiveData,            DIRECTIVE_DATA_DWORD|DIRECTIVE_NOCASHOFF } },
 	{ "dw",               { &parseDirectiveData,            DIRECTIVE_DATA_16|DIRECTIVE_NOCASHON } },
 	{ "dd",               { &parseDirectiveData,            DIRECTIVE_DATA_32|DIRECTIVE_NOCASHON } },
 	{ "dcb",              { &parseDirectiveData,            DIRECTIVE_DATA_8 } },
-	{ "dcw",              { &parseDirectiveData,            DIRECTIVE_DATA_16 } },
-	{ "dcd",              { &parseDirectiveData,            DIRECTIVE_DATA_32 } },
-	{ "dcq",              { &parseDirectiveData,            DIRECTIVE_DATA_64 } },
+	{ "dcw",              { &parseDirectiveData,            DIRECTIVE_DATA_HWORD } },
+	{ "dcd",              { &parseDirectiveData,            DIRECTIVE_DATA_WORD } },
+	{ "dcq",              { &parseDirectiveData,            DIRECTIVE_DATA_DWORD } },
+	{ ".d8",              { &parseDirectiveData,            DIRECTIVE_DATA_8 } },
+	{ ".d16",             { &parseDirectiveData,            DIRECTIVE_DATA_16 } },
+	{ ".d32",             { &parseDirectiveData,            DIRECTIVE_DATA_32 } },
+	{ ".d64",             { &parseDirectiveData,            DIRECTIVE_DATA_64 } },
 	{ ".float",           { &parseDirectiveData,            DIRECTIVE_DATA_FLOAT } },
 	{ ".double",          { &parseDirectiveData,            DIRECTIVE_DATA_DOUBLE } },
 	{ ".ascii",           { &parseDirectiveData,            DIRECTIVE_DATA_ASCII } },

--- a/Parser/DirectivesParser.h
+++ b/Parser/DirectivesParser.h
@@ -48,6 +48,9 @@ using DirectiveMap = std::unordered_multimap<std::string, const DirectiveEntry>;
 #define DIRECTIVE_DATA_CUSTOM		0x00000007
 #define DIRECTIVE_DATA_FLOAT		0x00000008
 #define DIRECTIVE_DATA_DOUBLE		0x00000009
+#define DIRECTIVE_DATA_HWORD        0x0000000A
+#define DIRECTIVE_DATA_WORD         0x0000000B
+#define DIRECTIVE_DATA_DWORD        0x0000000C
 #define DIRECTIVE_DATA_TERMINATION	0x00000100
 
 // message directive flags

--- a/Readme.md
+++ b/Readme.md
@@ -482,6 +482,12 @@ These directives can be used to set the architecture that the following assembly
 | `.saturn` | SEGA Saturn | SuperH | - |
 | `.32x` | SEGA 32x | SuperH | Alias to `.saturn` |
 
+| Architecture | Word size (in bits) |
+| ------------ |:---------------------|
+| MIPS | 32 |
+| ARM | 32 |
+| SuperH | 16 |
+
 ### Open a generic file
 
 ```
@@ -607,6 +613,7 @@ Inserts the file specified by `FileName` into the currently opened output file. 
 .byte   value[,...]
 .db     value[,...]
 .dcb    value[,...]
+.d8     value[,...]
 .ascii  value[,...]
 .asciiz value[,...]
 db      value[,...]
@@ -615,17 +622,27 @@ dcb     value[,...]
 
 Inserts the specified sequence of bytes. Each parameter can be any expression that evaluates to an integer or a string. If it evaluates to an integer or float, only the lowest 8 bits are inserted. If it evaluates to a string, every character is inserted as a byte using ASCII encoding.
 
+### Write 16/32/64-bit integers
+
+```
+.d16 value[,...]
+.d32 value[,...]
+.d64 value[,...]
+```
+Inserts the specified sequence of 16, 32, or 64-bit integers, depending on the directive used. If it evaluates to an integer or float, only the lowest 16/32/64 bits are inserted. If it evaluates to a string, every character is inserted as a 16/32/64-bit values using ASCII encoding.
+
 ### Write halfwords
 
 ```
 .halfword value[,...]
+.hword    value[,...]
 .dh       value[,...]
 .dcw      value[,...]
 dh        value[,...]
 dcw       value[,...]
 ```
 
-Inserts the specified sequence of 16-bit halfwords. Each parameter can be any expression that evaluates to an integer or a string. If it evaluates to an integer, only the lowest 16 bits are inserted. If it evaluates to a string, every character is inserted as a halfword using ASCII encoding.
+Inserts the specified sequence of halfwords. The size of a halfword is defined by architecture's word size. Each parameter can be any expression that evaluates to an integer or a string. If it evaluates to an integer, only the lowest 16/8 bits are inserted. If it evaluates to a string, every character is inserted as a halfword using ASCII encoding.
 
 If No$gba semantics are enabled, then `dh` and `.dh` are treated as invalid directives and will return an error.
 
@@ -639,23 +656,24 @@ dw    value[,...]
 dcd   value[,...]
 ```
 
-Inserts the specified sequence of 32-bit words. Each parameter can be any expression that evaluates to an integer, a string, or a floating point number. If it evaluates to an integer, only the lowest 32 bits are inserted. If it evaluates to a string, every character is inserted as a word using ASCII encoding. Floats are inserted using an integer representation of the single-precision float's encoding.
+Inserts the specified sequence of words. The size of a word is defined by architecture. Each parameter can be any expression that evaluates to an integer, a string, or a floating point number. If it evaluates to an integer, only the lowest 32/16 bits are inserted. If it evaluates to a string, every character is inserted as a word using ASCII encoding. Floats are inserted using an integer representation of the single-precision float's encoding.
 
-If No$gba semantics are enabled, then `dw` and `.dw` are treated as inserting 16-bit halfwords instead (i.e. equivalent to `.halfword`).
+If No$gba semantics are enabled, then `dw` and `.dw` are treated as inserting 16-bit values instead (i.e. equivalent to `.d16`).
 
 ### Write doublewords
 
 ```
 .doubleword value[,...]
+.dword      value[,...]
 .dd         value[,...]
 .dcq        value[,...]
 dd          value[,...]
 dcq         value[,...]
 ```
 
-Inserts the specified sequence of 64-bit doublewords. Each parameter can be any expression that evaluates to an integer, a string, or a floating point number. If it evaluates to a string, every character is inserted as a doubleword using ASCII encoding. Floats are inserted using an integer representation of the double-precision float's encoding.
+Inserts the specified sequence of doublewords. The size of a doubleword is defined by architecture's word size. Each parameter can be any expression that evaluates to an integer, a string, or a floating point number. If it evaluates to a string, every character is inserted as a doubleword using ASCII encoding. Floats are inserted using an integer representation of the double-precision float's encoding.
 
-If No$gba semantics are enabled, then `dd` and `.dd` are treated as inserting 32-bit words instead (i.e. equivalent to `.word`).
+If No$gba semantics are enabled, then `dd` and `.dd` are treated as inserting 32-bit values instead (i.e. equivalent to `.d32`).
 
 ### Write floating point numbers
 

--- a/Tests/SuperH/Immediates/Immediates.asm
+++ b/Tests/SuperH/Immediates/Immediates.asm
@@ -62,7 +62,7 @@ ForwardBranching:
 
     .align 4
 
-Some32BitValue: .dw 0x12345678, 0x87654321
-Some16BitValue: .dh 0x1234, 0x5678
+Some32BitValue: .dd 0x12345678, 0x87654321
+Some16BitValue: .dw 0x1234, 0x5678
 
 .close

--- a/Tests/SuperH/ImmediatesInvalid/ImmediatesInvalid.asm
+++ b/Tests/SuperH/ImmediatesInvalid/ImmediatesInvalid.asm
@@ -6,9 +6,9 @@
 
 .org 0x206
 OutofRangeValue16:
-    .dh 0x1234
+    .dw 0x1234
 .org 0x404
 OutofRangeValue32:
-    .dw 0x12345678
+    .dd 0x12345678
 
 .close

--- a/Tests/SuperH/Opcodes/Opcodes.asm
+++ b/Tests/SuperH/Opcodes/Opcodes.asm
@@ -36,7 +36,7 @@
 	nop
 	
 	.align 2
-	Immediate16BitValue: .dh 0xCCCC
+	Immediate16BitValue: .dw 0xCCCC
 
 	mov.l Immediate32BitValue, r0
 	mov.l Immediate32BitValue, r1
@@ -56,7 +56,7 @@
 	mov.l Immediate32BitValue, r15
 
 	.align 4
-	Immediate32BitValue: .dw 0xCCCCCCCC
+	Immediate32BitValue: .dd 0xCCCCCCCC
 
 	mov.w @(4,pc), r0
 	mov.w @(4,pc), r1


### PR DESCRIPTION
SuperH architecture uses 16-bit words, unlike ARM and MIPS. This PR changes the behavior of `.dh`, `.dw`, `.dd` and the like to match the current architecture's word size.
Directives `.d8`, `.d16`, `.d32` and `.d64` have also been added so that the user would be able to write 8/16/32/64 values without having to think about the architecture word size.
SuperH tests have also been edited to accommodate for these changes.