### PR TITLE
Fixes #239

### DIFF
--- a/Core/ELF/ElfRelocator.cpp
+++ b/Core/ELF/ElfRelocator.cpp
@@ -301,14 +301,21 @@ bool ElfRelocator::relocateFile(ElfRelocatorFile& file, int64_t& relocationAddre
 		size_t index = entry.index;
 		int size = section->getSize();
 
-		while (relocationAddress % section->getAlignment())
-			relocationAddress++;
+		if (section->getType() == SHT_NOBITS) 
+		{
+			// these sections should not be relocated...
+			relocationOffsets[index] = section->getAddress();
 
-		if (entry.label != nullptr)
-			entry.label->setValue(relocationAddress);
+		} else {
+			while (relocationAddress % section->getAlignment())
+				relocationAddress++;
 
-		relocationOffsets[index] = relocationAddress;
-		relocationAddress += size;
+			if (entry.label != nullptr)
+				entry.label->setValue(relocationAddress);
+
+			relocationOffsets[index] = relocationAddress;
+			relocationAddress += size;
+		}
 	}
 
 	size_t dataStart = outputData.size();


### PR DESCRIPTION
Fixes #239 by setting the relocation offset of `SHT_NOBITS` sections to the original offset from the ELF file instead of appending to the consecutive block where the ELF is loaded to.