### PR TITLE
Add a variant of .definelabel that avoids getting incremented when used from an object file, even when defined in THUMB mode

### DIFF
--- a/Archs/ARM/ArmParser.cpp
+++ b/Archs/ARM/ArmParser.cpp
@@ -56,6 +56,16 @@ std::unique_ptr<CAssemblerCommand> parseDirectivePool(Parser& parser, int flags)
 	return seq;
 }
 
+std::unique_ptr<CAssemblerCommand> parseDirectiveDefineArmLabel(Parser& parser, int flags)
+{
+	return parseDirectiveDefineLabel(parser, flags, false);
+}
+
+std::unique_ptr<CAssemblerCommand> parseDirectiveDefineThumbLabel(Parser& parser, int flags)
+{
+	return parseDirectiveDefineLabel(parser, flags, true);
+}
+
 const char* msgTemplate = R"(
 	mov    r12,r12
 	b      %after%
@@ -89,6 +99,8 @@ const DirectiveMap armDirectives = {
 	{ ".arm",		{ &parseDirectiveArm,	0 } },
 	{ ".pool",		{ &parseDirectivePool,	0 } },
 	{ ".msg",		{ &parseDirectiveMsg,	0 } },
+	{ ".definearmlabel",	{ &parseDirectiveDefineArmLabel,	0 } },
+	{ ".definethumblabel",	{ &parseDirectiveDefineThumbLabel,	0 } },
 };
 
 std::unique_ptr<CAssemblerCommand> ArmParser::parseDirective(Parser& parser)

--- a/Commands/CAssemblerLabel.cpp
+++ b/Commands/CAssemblerLabel.cpp
@@ -7,7 +7,7 @@
 #include "Core/SymbolData.h"
 #include "Util/Util.h"
 
-CAssemblerLabel::CAssemblerLabel(const Identifier& name, const Identifier& originalName)
+CAssemblerLabel::CAssemblerLabel(const Identifier& name, const Identifier& originalName, std::optional<bool> thumbMode)
 {
 	this->defined = false;
 	this->label = nullptr;
@@ -27,15 +27,15 @@ CAssemblerLabel::CAssemblerLabel(const Identifier& name, const Identifier& origi
 	// does this need to be in validate?
 	if (label->getUpdateInfo())
 	{
-		if (&Architecture::current() == &Arm && Arm.GetThumbMode())
-			label->setInfo(1);
-		else
+		if (&Architecture::current() != &Arm)
 			label->setInfo(0);
+		else
+			label->setInfo(thumbMode.value_or(Arm.GetThumbMode()));
 	}
 }
 
-CAssemblerLabel::CAssemblerLabel(const Identifier& name, const Identifier& originalName, Expression& value)
-	: CAssemblerLabel(name,originalName)
+CAssemblerLabel::CAssemblerLabel(const Identifier& name, const Identifier& originalName, Expression& value, std::optional<bool> thumbMode)
+	: CAssemblerLabel(name,originalName,thumbMode)
 {
 	labelValue = value;
 }

--- a/Commands/CAssemblerLabel.h
+++ b/Commands/CAssemblerLabel.h
@@ -4,13 +4,15 @@
 #include "Core/Expression.h"
 #include "Core/Types.h"
 
+#include <optional>
+
 class Label;
 
 class CAssemblerLabel: public CAssemblerCommand
 {
 public:
-	CAssemblerLabel(const Identifier& name, const Identifier& originalName);
-	CAssemblerLabel(const Identifier& name, const Identifier& originalName, Expression& value);
+	CAssemblerLabel(const Identifier& name, const Identifier& originalName, std::optional<bool> thumbMode = std::nullopt);
+	CAssemblerLabel(const Identifier& name, const Identifier& originalName, Expression& value, std::optional<bool> thumbMode = std::nullopt);
 	bool Validate(const ValidateState &state) override;
 	void Encode() const override;
 	void writeTempData(TempData& tempData) const override;

--- a/Parser/DirectivesParser.cpp
+++ b/Parser/DirectivesParser.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <initializer_list>
+#include <optional>
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveOpen(Parser& parser, int flags)
 {
@@ -618,7 +619,7 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveSym(Parser& parser, int flags)
 		return nullptr;
 }
 
-std::unique_ptr<CAssemblerCommand> parseDirectiveDefineLabel(Parser& parser, int flags)
+std::unique_ptr<CAssemblerCommand> parseDirectiveDefineLabel(Parser& parser, int flags, std::optional<bool> thumbMode)
 {
 	const Token& tok = parser.nextToken();
 	if (tok.type != TokenType::Identifier)
@@ -638,7 +639,17 @@ std::unique_ptr<CAssemblerCommand> parseDirectiveDefineLabel(Parser& parser, int
 		return nullptr;
 	}
 
-	return std::make_unique<CAssemblerLabel>(identifier,Identifier(tok.getOriginalText()),value);
+	return std::make_unique<CAssemblerLabel>(identifier,Identifier(tok.getOriginalText()),value,thumbMode);
+}
+
+std::unique_ptr<CAssemblerCommand> parseDirectiveDefineLabel(Parser& parser, int flags)
+{
+	return parseDirectiveDefineLabel(parser, flags, std::nullopt);
+}
+
+std::unique_ptr<CAssemblerCommand> parseDirectiveDefineDataLabel(Parser& parser, int flags)
+{
+	return parseDirectiveDefineLabel(parser, flags, false);
 }
 
 std::unique_ptr<CAssemblerCommand> parseDirectiveFunction(Parser& parser, int flags)
@@ -832,6 +843,7 @@ const DirectiveMap directives = {
 	{ ".sym",             { &parseDirectiveSym,             0 } },
 
 	{ ".definelabel",     { &parseDirectiveDefineLabel,     0 } },
+	{ ".definedatalabel", { &parseDirectiveDefineDataLabel, 0 } },
 	{ ".function",        { &parseDirectiveFunction,        DIRECTIVE_MANUALSEPARATOR } },
 	{ ".func",            { &parseDirectiveFunction,        DIRECTIVE_MANUALSEPARATOR } },
 

--- a/Parser/DirectivesParser.h
+++ b/Parser/DirectivesParser.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <optional>
 
 class CAssemblerCommand;
 class Parser;
@@ -78,3 +79,5 @@ using DirectiveMap = std::unordered_multimap<std::string, const DirectiveEntry>;
 #define DIRECTIVE_AREA_SHARED		0x00000001
 
 extern const DirectiveMap directives;
+
+std::unique_ptr<CAssemblerCommand> parseDirectiveDefineLabel(Parser& parser, int flags, std::optional<bool> thumbMode);

--- a/Readme.md
+++ b/Readme.md
@@ -765,6 +765,13 @@ Defines `Label` with a given value, creating a symbol for it. This can be used s
 
 Unlike `Label:`, note that `.definelabel Label,value` is evaluated only once, thus using any expressions that refer to the current state of the assembler (e.g. `org()`, `.`) in combination with `.definelabel` leads to undefined behavior.
 
+
+```
+.definedatalabel Label,value
+```
+
+For architectures other than ARM, this works identically to `.definelabel`, however it can be used to essentially document your intent that the symbol doesn't refer to code. Under ARM architecture, it works identically to `.definearmlabel` (see below).
+
 ### Function labels
 
 ```
@@ -894,6 +901,17 @@ ldr  r0,=0xFFEEDDCC
 ```
 
 Inserts a no$gba debug message as described by GBATEK.
+
+### Define labels
+
+```
+.definearmlabel Label,value
+.definethumblabel Label,value
+```
+
+Identical to `.definelabel`, but explicitly creates an ARM or THUMB label regardless of the current mode.
+
+Only relevant when linking external code through `.importobj`. ARM uses the least significant bit in addresses to signify whether the code at the target address is using ARM or THUMB mode when setting the program counter through instructions such as `bl` or `blx`.  armips automatically remembers the current mode when labels are defined, but this mode may be incorrect when using `.definelabel`. Note that using `.definethumblabel` for data may result in incorrect addresses.
 
 # 6. Macros
 


### PR DESCRIPTION
The situation this is trying to help with is basically this:

Assume this is `test.c` and it gets compiled with `-mthumb`:

```c
extern unsigned gLinkStatus;

unsigned getGLinkStatus() {
    return gLinkStatus;
}
```

And then this is `test.asm`:

```asm
.gba
.thumb

.open "rom.gba", "test.gba", 0x08000000

.org 0x0871A240
.importobj "test.o"

.close

.definelabel gLinkStatus, 0x03003F20
```

It assembles without complaint, but it's actually broken because the code inside the object file will actually try to read from 0x03003F21. This is because `gLinkStatus` was `.definelabel`ed in THUMB mode, and even though it's not a function, it still gets incremented when used by object files.

You can fix it by doing

```asm
.arm
.definelabel gLinkStatus, 0x03003F20
```

But that's easy to forget and there's no error or warning if you do so.

This implements (among other things) a `.defineobj`/`.defineobject` that works the way `.definelabel` works in ARM mode, even if you're actually in THUMB mode. So you could just do `.defineobj gLinkStatus, 0x03003F20` and it works.

Actually, this implements a few more variants of `.definelabel`: `.definefunc`, `.definearmfunc`, and `.definethumbfunc` (the first is an alias of `.definelabel` and the other two work the way you would probably expect from the names). I'm mostly interested in `.defineobj`, but they were easy to throw in.

While this works, I'm not really sure if this is really a reasonable way to do it. And even if it is generally sound, `ArmInfoMode` is a terrible name and it definitely doesn't belong in `Commands/CAssemblerLabel.h`. But I couldn't figure out a better name or place for it.

If you have any suggestions or concerns, please let me know.