### PR TITLE
Fix Windows builds of #247

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
     - name: Install
       shell: bash
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install
-        VERSION=$(git -C ${{github.workspace}} describe --first-parent)
+        cmake --build '${{github.workspace}}/build' --config ${{env.BUILD_TYPE}} --target install
+        VERSION=$(git -C '${{github.workspace}}' describe --first-parent)
         PLATFORM=$(echo ${{matrix.config.name}} | tr '[:upper:]' '[:lower:'] | sed 's/ /_/g')
         echo "FILENAME=armips_${VERSION}_${PLATFORM}" >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,15 @@ jobs:
           - { name: "Windows MSVC", os: "windows-2022", generator: "Visual Studio 17 2022"}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -G "${{matrix.config.generator}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DARMIPS_USE_STD_FILESYSTEM=ON
+      run: cmake -B ${{github.workspace}}/build -G "${{matrix.config.generator}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DARMIPS_USE_STD_FILESYSTEM=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
       env:
         CC: ${{matrix.config.cc}}
         CXX: ${{matrix.config.cxx}}
@@ -47,3 +50,16 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
+    - name: Install
+      shell: bash
+      run: |
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install
+        VERSION=$(git -C ${{github.workspace}} describe --first-parent)
+        PLATFORM=$(echo ${{matrix.config.name}} | tr '[:upper:]' '[:lower:'] | sed 's/ /_/g')
+        echo "FILENAME=armips_${VERSION}_${PLATFORM}" >> $GITHUB_ENV
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{env.FILENAME}}
+        path: ${{github.workspace}}/install


### PR DESCRIPTION
This PR is based off of #247 and fixes the issue of Windows builds breaking at the Install step.
The backward slashes inside `${{github.workspace}}` are interpreted as escape characters by bash, but it appears it can be fixed (according to https://stackoverflow.com/questions/66450348/need-to-convert-back-slashes-to-forward-slashes-in-github-action-work-flow) by single quoting uses of that variable, and this only needs to be done where bash is used over the default.