### PR TITLE
Statically link the linux builds in actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - { name: "Ubuntu gcc", os: "ubuntu-latest", generator: "Unix Makefiles", cc: "gcc", cxx: "g++" }
-          - { name: "Ubuntu clang", os: "ubuntu-latest", generator: "Unix Makefiles", cc: "clang", cxx: "clang++" }
+          - { name: "Ubuntu gcc", os: "ubuntu-latest", generator: "Unix Makefiles", cc: "gcc", cxx: "g++", cmake_flags: "-DCMAKE_EXE_LINKER_FLAGS='-static'" }
+          - { name: "Ubuntu clang", os: "ubuntu-latest", generator: "Unix Makefiles", cc: "clang", cxx: "clang++", cmake_flags: "-DCMAKE_EXE_LINKER_FLAGS='-static'" }
           - { name: "macOS clang", os: "macos-latest", generator: "Unix Makefiles", cc: "clang", cxx: "clang++" }
           - { name: "Windows clang", os: "windows-latest", generator: "Unix Makefiles", cc: "clang", cxx: "clang++" }
           - { name: "Windows MSVC", os: "windows-2022", generator: "Visual Studio 17 2022"}
@@ -35,7 +35,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -G "${{matrix.config.generator}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DARMIPS_USE_STD_FILESYSTEM=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
+      run: cmake -B ${{github.workspace}}/build -G "${{matrix.config.generator}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DARMIPS_USE_STD_FILESYSTEM=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install ${{matrix.config.cmake_flags}}
       env:
         CC: ${{matrix.config.cc}}
         CXX: ${{matrix.config.cxx}}


### PR DESCRIPTION
While testing the linux builds generated through the current actions on WSL2, I ran into the following errors:
```
./armips: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./armips)
./armips: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by ./armips)
```
This is due to linking dynamically against the standard library, and causes portability issues that can be difficult to resolve on the user's side (this issue does not exist when built locally). Instead, this pr changes the linux build on actions to be statically linked for maximum portability.